### PR TITLE
:rocket: Selection mapping, payload validation

### DIFF
--- a/Sources/SwiftGraphQL/Internal/Encode.swift
+++ b/Sources/SwiftGraphQL/Internal/Encode.swift
@@ -907,7 +907,7 @@ private extension __JSONEncoder {
             // JSONSerialization can natively handle NSDecimalNumber.
             return (value as! NSDecimalNumber)
         } else if value is _JSONStringDictionaryEncodableMarker {
-            return try self.box(value as! [String : Encodable])
+            return try self.box(value as Any as! [String : Encodable])
         }
 
         // The value should request a container from the __JSONEncoder.

--- a/Sources/SwiftGraphQLCodegen/Generator/Fragments.swift
+++ b/Sources/SwiftGraphQLCodegen/Generator/Fragments.swift
@@ -40,7 +40,7 @@ extension GraphQLCodegen {
             "    func on<Type>(",
         ]
         code.append(contentsOf: parameters.indent(by: 8))
-        code.append("    ) -> Type {")
+        code.append("    ) throws -> Type {")
         code.append(contentsOf: selection.indent(by: 8))
         code.append(contentsOf: decoder.indent(by: 8))
         code.append("    }")
@@ -71,10 +71,8 @@ extension GraphQLCodegen {
             // The last parameter shouldn't have a comma.
             return "\(name): data.\(name)\(isLast ? "" : ",")"
         }.indent(by: 8))
-        code.append(contentsOf: [
-            "    )",
-            "    return \(name.camelCase).decode(data: data)"
-        ])
+        code.append("    )")
+        code.append("    return try \(name.camelCase).decode(data: data)")
         
         return code
     }

--- a/Tests/SwiftGraphQLCodegenTests/Generator/FieldTests.swift
+++ b/Tests/SwiftGraphQLCodegenTests/Generator/FieldTests.swift
@@ -20,7 +20,7 @@ final class FieldTests: XCTestCase {
         let expected = """
         /// Object identifier.
         @available(*, deprecated, message: "Use ID instead.")
-        func id() -> String? {
+        func id() throws -> String? {
             /* Selection */
             let field = GraphQLField.leaf(
                 name: "id",
@@ -28,7 +28,7 @@ final class FieldTests: XCTestCase {
                 ]
             )
             self.select(field)
-        
+
             /* Decoder */
             switch self.response {
             case .fetched(let data):
@@ -60,7 +60,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func id() -> String {
+        func id() throws -> String {
             /* Selection */
             let field = GraphQLField.leaf(
                 name: "id",
@@ -68,11 +68,14 @@ final class FieldTests: XCTestCase {
                 ]
             )
             self.select(field)
-        
+
             /* Decoder */
             switch self.response {
             case .fetched(let data):
-                return data.id[field.alias!]!
+                if let data = data.id[field.alias!] {
+                    return data
+                }
+                throw SG.HttpError.badpayload
             case .fetching:
                 return String.mockValue
             }
@@ -98,7 +101,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func id() -> String? {
+        func id() throws -> String? {
             /* Selection */
             let field = GraphQLField.leaf(
                 name: "id",
@@ -106,7 +109,7 @@ final class FieldTests: XCTestCase {
                 ]
             )
             self.select(field)
-        
+
             /* Decoder */
             switch self.response {
             case .fetched(let data):
@@ -136,7 +139,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func ids() -> [String]? {
+        func ids() throws -> [String]? {
             /* Selection */
             let field = GraphQLField.leaf(
                 name: "ids",
@@ -144,7 +147,7 @@ final class FieldTests: XCTestCase {
                 ]
             )
             self.select(field)
-        
+
             /* Decoder */
             switch self.response {
             case .fetched(let data):
@@ -174,7 +177,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func ids() -> [String] {
+        func ids() throws -> [String] {
             /* Selection */
             let field = GraphQLField.leaf(
                 name: "ids",
@@ -186,7 +189,10 @@ final class FieldTests: XCTestCase {
             /* Decoder */
             switch self.response {
             case .fetched(let data):
-                return data.ids[field.alias!]!
+                if let data = data.ids[field.alias!] {
+                    return data
+                }
+                throw SG.HttpError.badpayload
             case .fetching:
                 return []
             }
@@ -214,7 +220,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func episode() -> Enums.Episode {
+        func episode() throws -> Enums.Episode {
             /* Selection */
             let field = GraphQLField.leaf(
                 name: "episode",
@@ -222,11 +228,14 @@ final class FieldTests: XCTestCase {
                 ]
             )
             self.select(field)
-        
+
             /* Decoder */
             switch self.response {
             case .fetched(let data):
-                return data.episode[field.alias!]!
+                if let data = data.episode[field.alias!] {
+                    return data
+                }
+                throw SG.HttpError.badpayload
             case .fetching:
                 return Enums.Episode.allCases.first!
             }
@@ -253,7 +262,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func episode() -> Enums.Episode? {
+        func episode() throws -> Enums.Episode? {
             /* Selection */
             let field = GraphQLField.leaf(
                 name: "episode",
@@ -261,7 +270,7 @@ final class FieldTests: XCTestCase {
                 ]
             )
             self.select(field)
-        
+
             /* Decoder */
             switch self.response {
             case .fetched(let data):
@@ -291,7 +300,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func episode() -> [Enums.Episode?] {
+        func episode() throws -> [Enums.Episode?] {
             /* Selection */
             let field = GraphQLField.leaf(
                 name: "episode",
@@ -303,7 +312,10 @@ final class FieldTests: XCTestCase {
             /* Decoder */
             switch self.response {
             case .fetched(let data):
-                return data.episode[field.alias!]!
+                if let data = data.episode[field.alias!] {
+                    return data
+                }
+                throw SG.HttpError.badpayload
             case .fetching:
                 return []
             }
@@ -331,7 +343,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func hero<Type>(_ selection: Selection<Type, Objects.Hero>) -> Type {
+        func hero<Type>(_ selection: Selection<Type, Objects.Hero>) throws -> Type {
             /* Selection */
             let field = GraphQLField.composite(
                 name: "hero",
@@ -340,11 +352,14 @@ final class FieldTests: XCTestCase {
                 selection: selection.selection
             )
             self.select(field)
-        
+
             /* Decoder */
             switch self.response {
             case .fetched(let data):
-                return selection.decode(data: data.hero[field.alias!]!)
+                if let data = data.hero[field.alias!] {
+                    return try selection.decode(data: data)
+                }
+                throw SG.HttpError.badpayload
             case .fetching:
                 return selection.mock()
             }
@@ -370,7 +385,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func hero<Type>(_ selection: Selection<Type, Objects.Hero?>) -> Type {
+        func hero<Type>(_ selection: Selection<Type, Objects.Hero?>) throws -> Type {
             /* Selection */
             let field = GraphQLField.composite(
                 name: "hero",
@@ -379,11 +394,11 @@ final class FieldTests: XCTestCase {
                 selection: selection.selection
             )
             self.select(field)
-        
+
             /* Decoder */
             switch self.response {
             case .fetched(let data):
-                return data.hero[field.alias!].map { selection.decode(data: $0) } ?? selection.mock()
+                return try selection.decode(data: data.hero[field.alias!])
             case .fetching:
                 return selection.mock()
             }
@@ -409,7 +424,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func hero<Type>(_ selection: Selection<Type, [Objects.Hero]>) -> Type {
+        func hero<Type>(_ selection: Selection<Type, [Objects.Hero]>) throws -> Type {
             /* Selection */
             let field = GraphQLField.composite(
                 name: "hero",
@@ -422,7 +437,10 @@ final class FieldTests: XCTestCase {
             /* Decoder */
             switch self.response {
             case .fetched(let data):
-                return selection.decode(data: data.hero[field.alias!]!)
+                if let data = data.hero[field.alias!] {
+                    return try selection.decode(data: data)
+                }
+                throw SG.HttpError.badpayload
             case .fetching:
                 return selection.mock()
             }
@@ -456,7 +474,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func hero(id: String) -> String {
+        func hero(id: String) throws -> String {
             /* Selection */
             let field = GraphQLField.leaf(
                 name: "hero",
@@ -469,7 +487,10 @@ final class FieldTests: XCTestCase {
             /* Decoder */
             switch self.response {
             case .fetched(let data):
-                return data.hero[field.alias!]!
+                if let data = data.hero[field.alias!] {
+                    return data
+                }
+                throw SG.HttpError.badpayload
             case .fetching:
                 return String.mockValue
             }
@@ -501,7 +522,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func hero(id: OptionalArgument<String> = .absent) -> String {
+        func hero(id: OptionalArgument<String> = .absent) throws -> String {
             /* Selection */
             let field = GraphQLField.leaf(
                 name: "hero",
@@ -514,7 +535,10 @@ final class FieldTests: XCTestCase {
             /* Decoder */
             switch self.response {
             case .fetched(let data):
-                return data.hero[field.alias!]!
+                if let data = data.hero[field.alias!] {
+                    return data
+                }
+                throw SG.HttpError.badpayload
             case .fetching:
                 return String.mockValue
             }
@@ -546,7 +570,7 @@ final class FieldTests: XCTestCase {
         )
         
         let expected = """
-        func hero(id: InputObjects.Input) -> String {
+        func hero(id: InputObjects.Input) throws -> String {
             /* Selection */
             let field = GraphQLField.leaf(
                 name: "hero",
@@ -555,11 +579,14 @@ final class FieldTests: XCTestCase {
                 ]
             )
             self.select(field)
-        
+
             /* Decoder */
             switch self.response {
             case .fetched(let data):
-                return data.hero[field.alias!]!
+                if let data = data.hero[field.alias!] {
+                    return data
+                }
+                throw SG.HttpError.badpayload
             case .fetching:
                 return String.mockValue
             }

--- a/Tests/SwiftGraphQLTests/Extensions/String+CaseTests.swift
+++ b/Tests/SwiftGraphQLTests/Extensions/String+CaseTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import SwiftGraphQL
+
+final class StringExtensionsTest: XCTestCase {
+    func testCamelCase() {
+        XCTAssertEqual("___a very peculiarNameIndeed__wouldNot.you.agree.AMAZING?____".camelCase, "aVeryPeculiarNameIndeedWouldNotYouAgreeAmazing")
+        XCTAssertEqual("ENUM".camelCase, "enum")
+        XCTAssertEqual("linkToURL".camelCase, "linkToUrl")
+        XCTAssertEqual("grandfather_father.son grandson".camelCase, "grandfatherFatherSonGrandson")
+    }
+    
+    func testPascalCase() {
+        XCTAssertEqual("grandfather_father.son grandson".pascalCase, "GrandfatherFatherSonGrandson")
+    }
+}

--- a/Tests/SwiftGraphQLTests/ResultTests.swift
+++ b/Tests/SwiftGraphQLTests/ResultTests.swift
@@ -18,7 +18,7 @@ final class ParserTests: XCTestCase {
             }
         }
         
-        let result = try GraphQLResult(data, with: selection)
+        let result = try GraphQLResult(data, with: selection.nonNullOrFail)
         
         /* Test */
         
@@ -49,7 +49,7 @@ final class ParserTests: XCTestCase {
             }
         }
         
-        let result = try GraphQLResult(response, with: selection)
+        let result = try GraphQLResult(response, with: selection.nonNullOrFail)
         
         /* Test */
         
@@ -95,13 +95,13 @@ final class ParserTests: XCTestCase {
         /* Test */
         
         XCTAssertEqual(
-            try GraphQLResult(data, with: selection),
-            try GraphQLResult(data, with: selection)
+            try GraphQLResult(data, with: selection.nonNullOrFail),
+            try GraphQLResult(data, with: selection.nonNullOrFail)
         )
         
         XCTAssertNotEqual(
-            try GraphQLResult(dataWithErrors, with: selection),
-            try GraphQLResult(data, with: selection)
+            try GraphQLResult(dataWithErrors, with: selection.nonNullOrFail),
+            try GraphQLResult(data, with: selection.nonNullOrFail)
         )
     }
 }

--- a/Tests/SwiftGraphQLTests/SelectionTests.swift
+++ b/Tests/SwiftGraphQLTests/SelectionTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import SwiftGraphQL
+
+final class SelectionTests: XCTestCase {
+    // MARK: - Type Wrappers
+    
+    func testNullable() throws {
+        
+        /* Data */
+        let data: Data = """
+        {
+          "data": null
+        }
+        """.data(using: .utf8)!
+        
+        /* Selection */
+        let selection = Selection<String, String> {
+            switch $0.response {
+            case .fetched(let data):
+                return data
+            case .fetching:
+                return "wrong"
+            }
+        }
+        
+        let result = try GraphQLResult(
+            data,
+            with: selection.nullable
+        )
+        
+        /* Test */
+        
+        XCTAssertEqual(result.data, nil)
+        XCTAssertEqual(result.errors, nil)
+    }
+    
+    func testList() throws {
+        /* Data */
+        let data: Data = """
+        {
+          "data": [1, 2, 3]
+        }
+        """.data(using: .utf8)!
+        let selection = Selection<Int, Int> {
+            switch $0.response {
+            case .fetched(let data):
+                return data
+            case .fetching:
+                return 0
+            }
+        }
+        
+        let result = try GraphQLResult(
+            data,
+            with: selection.list.nonNullOrFail
+        )
+        
+        /* Test */
+        
+        XCTAssertEqual(result.data, [1, 2, 3])
+        XCTAssertEqual(result.errors, nil)
+    }
+    
+    func testNonNullable() throws {
+        /* Data */
+        let data: Data = """
+        {
+          "data": null
+        }
+        """.data(using: .utf8)!
+        let selection = Selection<String, String> {
+            switch $0.response {
+            case .fetched(let data):
+                print(data)
+                return data
+            case .fetching:
+                return "wrong"
+            }
+        }
+        
+        /* Test */
+        XCTAssertThrowsError(
+            // Throwing function.
+            try GraphQLResult(
+                data,
+                with: selection.nonNullOrFail
+            )
+        ) { (error) -> Void in
+            // Errors with wrong data.
+            XCTAssertEqual(error as? SG.HttpError, SG.HttpError.badpayload)
+        }
+    }
+    
+    
+    // MARK: - Mapping
+    
+    func testSelectionMapping() throws {
+        /* Data */
+        let data: Data = """
+        {
+          "data": "right"
+        }
+        """.data(using: .utf8)!
+        let selection = Selection<String, String> {
+            switch $0.response {
+            case .fetched(let data):
+                return data
+            case .fetching:
+                return "wrong"
+            }
+        }
+        
+        let result = try GraphQLResult(
+            data,
+            with: selection.map { $0 == "right" }.nonNullOrFail
+        )
+        
+        /* Test */
+        
+        XCTAssertEqual(result.data, true)
+        XCTAssertEqual(result.errors, nil)
+    }
+    
+}

--- a/ete_tests/StarWars/StarWars.xcodeproj/project.pbxproj
+++ b/ete_tests/StarWars/StarWars.xcodeproj/project.pbxproj
@@ -68,8 +68,8 @@
 			children = (
 				0243193D254AADF200094333 /* Scalars */,
 				02CA03ED253CA05B00B05BD1 /* API.swift */,
-				02208E76253C596D00014850 /* Main.swift */,
 				02208E78253C596D00014850 /* ContentView.swift */,
+				02208E76253C596D00014850 /* Main.swift */,
 				02208E7A253C596E00014850 /* Assets.xcassets */,
 				02208E7F253C596E00014850 /* Info.plist */,
 				02208E7C253C596E00014850 /* Preview Content */,

--- a/ete_tests/StarWars/StarWars/API.swift
+++ b/ete_tests/StarWars/StarWars/API.swift
@@ -120,7 +120,7 @@ extension Operations.Query: Decodable {
 }
 
 extension SelectionSet where TypeLock == Operations.Query {
-    func human<Type>(id: String, _ selection: Selection<Type, Objects.Human?>) -> Type {
+    func human<Type>(id: String, _ selection: Selection<Type, Objects.Human?>) throws -> Type {
         /* Selection */
         let field = GraphQLField.composite(
             name: "human",
@@ -134,12 +134,12 @@ extension SelectionSet where TypeLock == Operations.Query {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.human[field.alias!].map { selection.decode(data: $0) } ?? selection.mock()
+            return try selection.decode(data: data.human[field.alias!])
         case .fetching:
             return selection.mock()
         }
     }
-    func droid<Type>(id: String, _ selection: Selection<Type, Objects.Droid?>) -> Type {
+    func droid<Type>(id: String, _ selection: Selection<Type, Objects.Droid?>) throws -> Type {
         /* Selection */
         let field = GraphQLField.composite(
             name: "droid",
@@ -153,12 +153,12 @@ extension SelectionSet where TypeLock == Operations.Query {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.droid[field.alias!].map { selection.decode(data: $0) } ?? selection.mock()
+            return try selection.decode(data: data.droid[field.alias!])
         case .fetching:
             return selection.mock()
         }
     }
-    func character<Type>(id: String, _ selection: Selection<Type, Unions.CharacterUnion?>) -> Type {
+    func character<Type>(id: String, _ selection: Selection<Type, Unions.CharacterUnion?>) throws -> Type {
         /* Selection */
         let field = GraphQLField.composite(
             name: "character",
@@ -172,12 +172,12 @@ extension SelectionSet where TypeLock == Operations.Query {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.character[field.alias!].map { selection.decode(data: $0) } ?? selection.mock()
+            return try selection.decode(data: data.character[field.alias!])
         case .fetching:
             return selection.mock()
         }
     }
-    func luke<Type>(_ selection: Selection<Type, Objects.Human?>) -> Type {
+    func luke<Type>(_ selection: Selection<Type, Objects.Human?>) throws -> Type {
         /* Selection */
         let field = GraphQLField.composite(
             name: "luke",
@@ -190,12 +190,12 @@ extension SelectionSet where TypeLock == Operations.Query {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.luke[field.alias!].map { selection.decode(data: $0) } ?? selection.mock()
+            return try selection.decode(data: data.luke[field.alias!])
         case .fetching:
             return selection.mock()
         }
     }
-    func humans<Type>(_ selection: Selection<Type, [Objects.Human]>) -> Type {
+    func humans<Type>(_ selection: Selection<Type, [Objects.Human]>) throws -> Type {
         /* Selection */
         let field = GraphQLField.composite(
             name: "humans",
@@ -208,12 +208,15 @@ extension SelectionSet where TypeLock == Operations.Query {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return selection.decode(data: data.humans[field.alias!]!)
+            if let data = data.humans[field.alias!] {
+                return try selection.decode(data: data)
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return selection.mock()
         }
     }
-    func droids<Type>(_ selection: Selection<Type, [Objects.Droid]>) -> Type {
+    func droids<Type>(_ selection: Selection<Type, [Objects.Droid]>) throws -> Type {
         /* Selection */
         let field = GraphQLField.composite(
             name: "droids",
@@ -226,12 +229,15 @@ extension SelectionSet where TypeLock == Operations.Query {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return selection.decode(data: data.droids[field.alias!]!)
+            if let data = data.droids[field.alias!] {
+                return try selection.decode(data: data)
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return selection.mock()
         }
     }
-    func characters<Type>(_ selection: Selection<Type, [Interfaces.Character]>) -> Type {
+    func characters<Type>(_ selection: Selection<Type, [Interfaces.Character]>) throws -> Type {
         /* Selection */
         let field = GraphQLField.composite(
             name: "characters",
@@ -244,12 +250,15 @@ extension SelectionSet where TypeLock == Operations.Query {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return selection.decode(data: data.characters[field.alias!]!)
+            if let data = data.characters[field.alias!] {
+                return try selection.decode(data: data)
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return selection.mock()
         }
     }
-    func greeting(input: OptionalArgument<InputObjects.Greeting> = .absent) -> String {
+    func greeting(input: OptionalArgument<InputObjects.Greeting> = .absent) throws -> String {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "greeting",
@@ -262,12 +271,15 @@ extension SelectionSet where TypeLock == Operations.Query {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.greeting[field.alias!]!
+            if let data = data.greeting[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return String.mockValue
         }
     }
-    func whoami() -> String {
+    func whoami() throws -> String {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "whoami",
@@ -279,12 +291,15 @@ extension SelectionSet where TypeLock == Operations.Query {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.whoami[field.alias!]!
+            if let data = data.whoami[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return String.mockValue
         }
     }
-    func time() -> DateTime {
+    func time() throws -> DateTime {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "time",
@@ -296,7 +311,10 @@ extension SelectionSet where TypeLock == Operations.Query {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.time[field.alias!]!
+            if let data = data.time[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return DateTime.mockValue
         }
@@ -382,7 +400,7 @@ extension Objects.Droid: Decodable {
 }
 
 extension SelectionSet where TypeLock == Objects.Droid {
-    func id() -> String {
+    func id() throws -> String {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "id",
@@ -394,12 +412,15 @@ extension SelectionSet where TypeLock == Objects.Droid {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.id[field.alias!]!
+            if let data = data.id[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return String.mockValue
         }
     }
-    func name() -> String {
+    func name() throws -> String {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "name",
@@ -411,12 +432,15 @@ extension SelectionSet where TypeLock == Objects.Droid {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.name[field.alias!]!
+            if let data = data.name[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return String.mockValue
         }
     }
-    func primaryFunction() -> String {
+    func primaryFunction() throws -> String {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "primaryFunction",
@@ -428,12 +452,15 @@ extension SelectionSet where TypeLock == Objects.Droid {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.primaryFunction[field.alias!]!
+            if let data = data.primaryFunction[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return String.mockValue
         }
     }
-    func appearsIn() -> [Enums.Episode] {
+    func appearsIn() throws -> [Enums.Episode] {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "appearsIn",
@@ -445,7 +472,10 @@ extension SelectionSet where TypeLock == Objects.Droid {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.appearsIn[field.alias!]!
+            if let data = data.appearsIn[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return []
         }
@@ -534,7 +564,7 @@ extension Objects.Human: Decodable {
 }
 
 extension SelectionSet where TypeLock == Objects.Human {
-    func id() -> String {
+    func id() throws -> String {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "id",
@@ -546,12 +576,15 @@ extension SelectionSet where TypeLock == Objects.Human {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.id[field.alias!]!
+            if let data = data.id[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return String.mockValue
         }
     }
-    func name() -> String {
+    func name() throws -> String {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "name",
@@ -563,13 +596,16 @@ extension SelectionSet where TypeLock == Objects.Human {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.name[field.alias!]!
+            if let data = data.name[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return String.mockValue
         }
     }
     /// The home planet of the human, or null if unknown.
-    func homePlanet() -> String? {
+    func homePlanet() throws -> String? {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "homePlanet",
@@ -586,7 +622,7 @@ extension SelectionSet where TypeLock == Objects.Human {
             return nil
         }
     }
-    func appearsIn() -> [Enums.Episode] {
+    func appearsIn() throws -> [Enums.Episode] {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "appearsIn",
@@ -598,12 +634,15 @@ extension SelectionSet where TypeLock == Objects.Human {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.appearsIn[field.alias!]!
+            if let data = data.appearsIn[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return []
         }
     }
-    func infoUrl() -> String? {
+    func infoUrl() throws -> String? {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "infoURL",
@@ -721,7 +760,7 @@ extension Interfaces.Character: Decodable {
 
 extension SelectionSet where TypeLock == Interfaces.Character {
     /// The id of the character
-    func id() -> String {
+    func id() throws -> String {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "id",
@@ -733,13 +772,16 @@ extension SelectionSet where TypeLock == Interfaces.Character {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.id[field.alias!]!
+            if let data = data.id[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return String.mockValue
         }
     }
     /// The name of the character
-    func name() -> String {
+    func name() throws -> String {
         /* Selection */
         let field = GraphQLField.leaf(
             name: "name",
@@ -751,7 +793,10 @@ extension SelectionSet where TypeLock == Interfaces.Character {
         /* Decoder */
         switch self.response {
         case .fetched(let data):
-            return data.name[field.alias!]!
+            if let data = data.name[field.alias!] {
+                return data
+            }
+            throw SG.HttpError.badpayload
         case .fetching:
             return String.mockValue
         }
@@ -762,7 +807,7 @@ extension SelectionSet where TypeLock == Interfaces.Character {
     func on<Type>(
         droid: Selection<Type, Objects.Droid>,
         human: Selection<Type, Objects.Human>
-    ) -> Type {
+    ) throws -> Type {
         /* Selection */
         self.select([
             GraphQLField.fragment(type: "Droid", selection: droid.selection),
@@ -779,7 +824,7 @@ extension SelectionSet where TypeLock == Interfaces.Character {
                     primaryFunction: data.primaryFunction,
                     appearsIn: data.appearsIn
                 )
-                return droid.decode(data: data)
+                return try droid.decode(data: data)
             case .human:
                 let data = Objects.Human(
                     id: data.id,
@@ -788,7 +833,7 @@ extension SelectionSet where TypeLock == Interfaces.Character {
                     appearsIn: data.appearsIn,
                     infoUrl: data.infoUrl
                 )
-                return human.decode(data: data)
+                return try human.decode(data: data)
             }
         case .fetching:
             return droid.mock()
@@ -897,7 +942,7 @@ extension SelectionSet where TypeLock == Unions.CharacterUnion {
     func on<Type>(
         human: Selection<Type, Objects.Human>,
         droid: Selection<Type, Objects.Droid>
-    ) -> Type {
+    ) throws -> Type {
         /* Selection */
         self.select([
             GraphQLField.fragment(type: "Human", selection: human.selection),
@@ -915,7 +960,7 @@ extension SelectionSet where TypeLock == Unions.CharacterUnion {
                     appearsIn: data.appearsIn,
                     infoUrl: data.infoUrl
                 )
-                return human.decode(data: data)
+                return try human.decode(data: data)
             case .droid:
                 let data = Objects.Droid(
                     id: data.id,
@@ -923,7 +968,7 @@ extension SelectionSet where TypeLock == Unions.CharacterUnion {
                     primaryFunction: data.primaryFunction,
                     appearsIn: data.appearsIn
                 )
-                return droid.decode(data: data)
+                return try droid.decode(data: data)
             }
         case .fetching:
             return human.mock()

--- a/ete_tests/StarWars/StarWars/ContentView.swift
+++ b/ete_tests/StarWars/StarWars/ContentView.swift
@@ -12,11 +12,11 @@ struct Character: Identifiable {
 
 let character = Selection<Character, Interfaces.Character> {
     Character(
-        id: $0.id(),
-        name: $0.name(),
-        message: $0.on(
-            droid: .init { $0.primaryFunction() },
-            human: .init { $0.homePlanet() ?? "Unknown" }
+        id: try $0.id(),
+        name: try $0.name(),
+        message: try $0.on(
+            droid: .init { try $0.primaryFunction() },
+            human: .init { try $0.homePlanet() ?? "Unknown" }
         )
     )
 }
@@ -29,30 +29,32 @@ struct Human {
 
 let human = Selection<Human, Objects.Human> {
     Human(
-        id: $0.id(),
-        name: $0.name(),
-        url: $0.infoUrl()
+        id: try $0.id(),
+        name: try $0.name(),
+        url: try $0.infoUrl()
     )
 }
+
+let foo: Selection<Human?, Objects.Human> = human.map { $0 }
 
 let characterInterface = Selection<String, Interfaces.Character> {
     
     /* Common */
-    let name = $0.name()
+    let name = try $0.name()
     
     /* Fragments */
-    let about = $0.on(
-        droid: Selection<String, Objects.Droid> { droid in droid.primaryFunction() },
-        human: Selection<String, Objects.Human> { human in human.infoUrl() ?? "Unknown" }
+    let about = try $0.on(
+        droid: Selection<String, Objects.Droid> { droid in try droid.primaryFunction() },
+        human: Selection<String, Objects.Human> { human in try human.infoUrl() ?? "Unknown" }
     )
     
     return "\(name). \(about)"
 }
 
 let characterUnion = Selection<String, Unions.CharacterUnion> {
-    $0.on(
-        human: .init { $0.infoUrl() ?? "Unknown" },
-        droid: .init { $0.primaryFunction() }
+    try $0.on(
+        human: .init { try $0.infoUrl() ?? "Unknown" },
+        droid: .init { try $0.primaryFunction() }
     )
 }
 
@@ -65,17 +67,17 @@ struct Model {
 }
 
 let query = Selection<Model, Operations.Query> {
-    let english = $0.greeting()
-    let slovene = $0.greeting(input: .present(.init(name: "Matic")))
+    let english = try $0.greeting()
+    let slovene = try $0.greeting(input: .present(.init(name: "Matic")))
     
     let greeting = "\(english); \(slovene)"
     
     return Model(
-        whoami: $0.whoami(),
-        time: $0.time(),
+        whoami: try $0.whoami(),
+        time: try $0.time(),
         greeting: greeting,
-        character: $0.character(id: "1000", characterUnion.nonNullOrFail),
-        characters: $0.characters(Selection.list(character))
+        character: try $0.character(id: "1000", characterUnion.nonNullOrFail),
+        characters: try $0.characters(Selection.list(character))
     )
 }
 
@@ -106,9 +108,7 @@ class AppState: ObservableObject {
                 print("DATA")
                 print(data)
                 DispatchQueue.main.async {
-                    if let data = data.data {
-                        self.model = data
-                    }
+                    self.model = data.data
                 }
             } catch let error {
                 print("ERROR")


### PR DESCRIPTION
This commit includes utility functions for mapping a Selection, and numerous improvements to internal data handling.

I've streamlined GraphQLResult structure so that it more accurately represents the return value.

Field accessors may now fail to reflect the possibility of a bad payload. This is a huge improvement over the previous approach since we no longer trigger a fatal error whenever the data is corrupt, but instead throw a bad payload error.

Additionally, we require that query selection is optional since it might fail. To prevent endless nullability wrappings, I've created a utility send function that wrapps selection in `nonNullOrFail` selection.