### PR TITLE
add optional headers to the code generation, and fix argument naming

### DIFF
--- a/Sources/GraphQLAST/Introspection.swift
+++ b/Sources/GraphQLAST/Introspection.swift
@@ -144,9 +144,13 @@ private struct IntrospectionQuery: Decodable, Equatable {
 // MARK: - Loader
 
 /// Fetches a schema from the provided endpoint using introspection query.
-func fetch(from endpoint: URL) throws -> Data {
+func fetch(from endpoint: URL, withHeaders headers: [String: String] = [:]) throws -> Data {
     /* Compose a request. */
     var request = URLRequest(url: endpoint)
+
+    for header in headers {
+        request.setValue(header.value, forHTTPHeaderField: header.key)
+    }
 
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -209,8 +213,8 @@ enum IntrospectionError: Error {
 
 public extension Schema {
     /// Downloads a schema from the provided endpoint.
-    init(from endpoint: URL) throws {
-        let introspection: Data = try fetch(from: endpoint)
+    init(from endpoint: URL, withHeaders headers: [String: String] = [:]) throws {
+        let introspection: Data = try fetch(from: endpoint, withHeaders: headers)
         self = try parse(introspection)
     }
 }

--- a/Sources/SwiftGraphQL/OptionalArgument.swift
+++ b/Sources/SwiftGraphQL/OptionalArgument.swift
@@ -20,7 +20,7 @@ public struct OptionalArgument<Type>: OptionalArgumentProtocol {
     // MARK: - Initializer
 
     public enum Value {
-        case present(Type)
+        indirect case present(Type)
         case absent
         case null
     }

--- a/Sources/SwiftGraphQLCodegen/Extensions/String+Normalize.swift
+++ b/Sources/SwiftGraphQLCodegen/Extensions/String+Normalize.swift
@@ -69,6 +69,10 @@ let reservedWords = [
     "throws",
     "true",
     "try",
+    /* Booleans */
+    "not",
+    "and",
+    "or",
     /* Keywords used in patterns */
     "_",
     // NOTE: There are other reserved keywords, but they aren't important in context.

--- a/Sources/SwiftGraphQLCodegen/Generator.swift
+++ b/Sources/SwiftGraphQLCodegen/Generator.swift
@@ -23,8 +23,8 @@ public struct GraphQLCodegen {
     /// Generates a target SwiftGraphQL Selection file.
     ///
     /// - parameter from: GraphQL server endpoint.
-    public func generate(from endpoint: URL) throws -> String {
-        let schema = try Schema(from: endpoint)
+    public func generate(from endpoint: URL, withHeaders headers: [String: String] = [:]) throws -> String {
+        let schema = try Schema(from: endpoint, withHeaders: headers)
         let code = try generate(schema: schema)
         return code
     }

--- a/Sources/SwiftGraphQLCodegen/Generator/Codable.swift
+++ b/Sources/SwiftGraphQLCodegen/Generator/Codable.swift
@@ -37,7 +37,7 @@ extension Structure {
             }
         }
 
-        return shared.unique(by: { $0.name })
+        return shared.unique(by: { $0.name }).sorted(by: {$0.name < $1.name})
     }
 }
 

--- a/Sources/SwiftGraphQLCodegen/Generator/Field.swift
+++ b/Sources/SwiftGraphQLCodegen/Generator/Field.swift
@@ -174,7 +174,7 @@ private extension Collection where Element == InputValue {
 private extension InputValue {
     /// Returns a SwiftGraphQL Argument definition for a given input value.
     var argument: String {
-        #"Argument(name: "\#(name.camelCase)", type: "\#(type.argument)", value: \#(name.camelCase.normalize))"#
+        #"Argument(name: "\#(name)", type: "\#(type.argument)", value: \#(name.camelCase.normalize))"#
     }
 }
 


### PR DESCRIPTION
Hi Matic,
Love the project. I began using it in order to interface with Hasura, and encountered some minor bugs pertaining to the generation of Hasura-style queries. I believe my fix (namely keeping the original argument's name in the query, as opposed to its camelCase version) should interoperate with all GraphQL backends. The OptionalArguments enum suffered from cyclic references in my use case, so I made the `.present(*)` case `indirect.`

I also added optional headers to the code generator's requests in case anyone needs to pull the schema from a remote server.