### PR TITLE
Fix string case format

### DIFF
--- a/Sources/SwiftGraphQLCodegen/Extensions/String+Case.swift
+++ b/Sources/SwiftGraphQLCodegen/Extensions/String+Case.swift
@@ -50,11 +50,22 @@ extension String {
             if lowerCaseRange.lowerBound == nextCharacterAfterDelimiter {
                 continue
             } else {
-                // There was a range of >1 capital letters. Turn those into a word, stopping at the capital before the lower case character.
-                words.append(wordStart ..< lowerCaseRange.lowerBound)
+                // There was a range of >1 capital letters.
 
-                // Next word starts at the capital before the lowercase we just found
-                wordStart = index(after: lowerCaseRange.lowerBound)
+                // If the next character after the capital letters is not a letter, turn all the capital letters into a word.
+                // Else turn all the capital letters up the second last index into a word.
+                if !self[lowerCaseRange.lowerBound].isLetter {
+                    words.append(wordStart ..< lowerCaseRange.lowerBound)
+
+                    // Next word starts after capital letters we just found
+                    wordStart = lowerCaseRange.lowerBound
+                } else {
+                    words.append(wordStart ..< index(before: lowerCaseRange.lowerBound))
+
+                    // Next word starts at the last capital letters we just found
+                    wordStart = index(before: lowerCaseRange.lowerBound)
+                }
+
                 searchRange = wordStart ..< searchRange.upperBound
             }
         }

--- a/Tests/SwiftGraphQLCodegenTests/Extensions/String+CaseTests.swift
+++ b/Tests/SwiftGraphQLCodegenTests/Extensions/String+CaseTests.swift
@@ -1,4 +1,4 @@
-@testable import SwiftGraphQLCodegen
+@testable import SwiftGraphQL
 import XCTest
 
 final class StringExtensionsTest: XCTestCase {
@@ -7,6 +7,7 @@ final class StringExtensionsTest: XCTestCase {
         XCTAssertEqual("ENUM".camelCase, "enum")
         XCTAssertEqual("linkToURL".camelCase, "linkToUrl")
         XCTAssertEqual("grandfather_father.son grandson".camelCase, "grandfatherFatherSonGrandson")
+        XCTAssertEqual("GRAndFATHER_Father.son".camelCase, "grAndFatherFatherSon")
     }
 
     func testPascalCase() {


### PR DESCRIPTION
Referencing to this issue https://github.com/maticzav/swift-graphql/issues/42 regarding string case not being formatted correctly when there are a group of capital letters

Example of the problematic output
```
APIKey -> apikY
FirmwareNRFMetadata -> firmwareNrfmTadata
```

Example of the fixed output
```
APIKey -> apiKey
FirmwareNRFMetadata -> FirmwareNrfMetadata
```