### PR TITLE
Make the `interfaces` property of `ObjectType` and `InterfaceType` optional

### DIFF
--- a/Sources/GraphQLAST/Type.swift
+++ b/Sources/GraphQLAST/Type.swift
@@ -50,7 +50,7 @@ public struct ObjectType: NamedTypeProtocol, Decodable, Equatable {
     public let description: String?
 
     public let fields: [Field]
-    public let interfaces: [InterfaceTypeRef]
+    public let interfaces: [InterfaceTypeRef]?
 }
 
 public struct InterfaceType: NamedTypeProtocol, Decodable, Equatable {
@@ -59,7 +59,7 @@ public struct InterfaceType: NamedTypeProtocol, Decodable, Equatable {
     public let description: String?
 
     public let fields: [Field]
-    public let interfaces: [InterfaceTypeRef]
+    public let interfaces: [InterfaceTypeRef]?
     public let possibleTypes: [ObjectTypeRef]
 }
 


### PR DESCRIPTION
Should resolve #41, which is caused by some schemas declaring the `interfaces` property  as `null` instead of `[]`

The [Magento](https://devdocs.magento.com/guides/v2.4/graphql/) demo endpoint at `https://venia.magento.com/graphql` exhibits this:
```graphql
{
  "data": {
    "__schema": {
      ...
      "subscriptionType": null,
      "types": [
        ...
        {
          "kind": "INTERFACE",
          "name": "CartAddressInterface",
          "description": "",
          "fields": [ ... ],
          "inputFields": null,
          "interfaces": null,
          "enumValues": null,
          "possibleTypes": [ ... ]
        }
     ...
```