### PR TITLE
use exact version of pre-1.0 package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/JohnSundell/Files", from: "4.0.0"),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.41.2"),
+        .package(url: "https://github.com/nicklockwood/SwiftFormat", .exact("0.49.4")),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.4"),
     ],


### PR DESCRIPTION
The only reason I recommend this change is because of the lax nature of versioning in this pre-1.0 package (see [SwiftFormat's contribution guidelines](https://github.com/nicklockwood/SwiftFormat/blob/master/CONTRIBUTING.md#branches-and-versioning)). I believe the linked issue occurred because of this very problem. I also submitted a [PR](https://github.com/nicklockwood/SwiftFormat/pull/1159) fixing the SwiftFormat error, but this fixed the make install for me in the meantime.

Fixes #71 