### PR TITLE
Updated subscription code

### DIFF
--- a/Sources/SwiftGraphQL/HTTP+WebSockets.swift
+++ b/Sources/SwiftGraphQL/HTTP+WebSockets.swift
@@ -113,7 +113,7 @@ public class GraphQLSocket<S: GraphQLEnabledSocket> {
                         return true
                     case .pong:
                         self?.state = .running
-                    case .start, .connection_init, .ping:
+                    case .subscribe, .connection_init, .ping:
                         _ = "The server will never send these messages"
                     }
                     
@@ -236,7 +236,7 @@ public class GraphQLSocket<S: GraphQLEnabledSocket> {
                     case .complete:
                         eventHandler(.failure(.complete))
                     case .ka, .pong: ()
-                    case .connection_init, .connection_ack, .start, .ping:
+                    case .connection_init, .connection_ack, .subscribe, .ping:
                         os_log("Invalid subscription case %{public}@", log: OSLog.subscription, type: .debug, message.type.rawValue)
                         assertionFailure()
                     }
@@ -277,7 +277,7 @@ public struct GraphQLSocketMessage: Codable {
     public enum MessageType: String, Codable {
         case connection_init
         case connection_ack
-        case start
+        case subscribe
         case next
         case error
         case complete
@@ -346,7 +346,7 @@ extension GraphQLSocketMessage {
     /// Requests an operation specified in the message `payload`. This message provides a
     /// unique ID field to connect published messages to the operation requested by this message.
     public static func subscribe<P>(_ payload: P, id: String) -> GraphQLSocketMessage {
-        return .init(type: .start, id: id, addedPayload: AnyCodable(payload))
+        return .init(type: .subscribe, id: id, addedPayload: AnyCodable(payload))
     }
     
     /// Indicates that the client has stopped listening and wants to complete the subscription.

--- a/Sources/SwiftGraphQL/HTTP+WebSockets.swift
+++ b/Sources/SwiftGraphQL/HTTP+WebSockets.swift
@@ -97,7 +97,7 @@ public class GraphQLSocket<S: GraphQLEnabledSocket> {
                         self?.subscriptions[id]?(message)
                     case .connection_terminate:
                         self?.stop()
-                    case .subscribe, .connection_init:
+                    case .start, .connection_init:
                         _ = "The server will never send these messages"
                     }
                     
@@ -190,7 +190,7 @@ public class GraphQLSocket<S: GraphQLEnabledSocket> {
                     case .complete:
                         eventHandler(.failure(.complete))
                     case .ka: ()
-                    case .connection_init, .connection_ack, .subscribe:
+                    case .connection_init, .connection_ack, .start:
                         os_log("Invalid subscription case %{public}@", log: OSLog.subscription, type: .debug, message.type.rawValue)
                         assertionFailure()
                     }
@@ -231,7 +231,7 @@ public struct GraphQLSocketMessage: Codable {
     public enum MessageType: String, Codable {
         case connection_init
         case connection_ack
-        case subscribe
+        case start
         case next
         case error
         case complete
@@ -294,7 +294,7 @@ extension GraphQLSocketMessage {
     /// Requests an operation specified in the message `payload`. This message provides a
     /// unique ID field to connect published messages to the operation requested by this message.
     public static func subscribe<P>(_ payload: P, id: String) -> GraphQLSocketMessage {
-        return .init(type: .subscribe, id: id, addedPayload: AnyCodable(payload))
+        return .init(type: .start, id: id, addedPayload: AnyCodable(payload))
     }
     
     /// Indicates that the client has stopped listening and wants to complete the subscription.

--- a/Sources/SwiftGraphQL/HTTP+WebSockets.swift
+++ b/Sources/SwiftGraphQL/HTTP+WebSockets.swift
@@ -72,10 +72,10 @@ public class GraphQLSocket<S: GraphQLEnabledSocket> {
             lastConnectionParams = AnyCodable(connectionParams)
             let message = Message.connectionInit(connectionParams)
             let messageData = try encoder.encode(message)
-            os_log("Start Connection: %{public}@",
-                   log: OSLog.subscription,
-                   type: .debug,
-                   (String(data: messageData, encoding: .utf8) ?? "Invalid .utf8")
+//            os_log("Start Connection: %{public}@",
+//                   log: OSLog.subscription,
+//                   type: .debug,
+//                   (String(data: messageData, encoding: .utf8) ?? "Invalid .utf8")
             )
             state = .started
             socket = S.create(with: initParams, errorHandler: errorHandler)
@@ -86,10 +86,10 @@ public class GraphQLSocket<S: GraphQLEnabledSocket> {
             socket?.receiveMessages { [weak self] (message) in
                 switch message {
                 case .success(let data):
-                    os_log("Received Data: %{public}@",
-                           log: OSLog.subscription,
-                           type: .debug, (String(data: data, encoding: .utf8) ?? "Invalid .utf8")
-                    )
+//                    os_log("Received Data: %{public}@",
+//                           log: OSLog.subscription,
+//                           type: .debug, (String(data: data, encoding: .utf8) ?? "Invalid .utf8")
+//                    )
                     guard let message = try? JSONDecoder().decode(Message.self, from: data) else {
                         os_log("Invalid JSON Payload", log: OSLog.subscription, type: .debug)
                         return false
@@ -208,10 +208,10 @@ public class GraphQLSocket<S: GraphQLEnabledSocket> {
                 let payload = selection.buildPayload(operationName: operationName)
                 let message = Message.subscribe(payload, id: id)
                 let messageData = try encoder.encode(message)
-                os_log("Outgoing Data: %{public}@",
-                       log: OSLog.subscription,
-                       type: .debug, (String(data: messageData, encoding: .utf8) ?? "Invalid .utf8")
-                )
+//                os_log("Outgoing Data: %{public}@",
+//                       log: OSLog.subscription,
+//                       type: .debug, (String(data: messageData, encoding: .utf8) ?? "Invalid .utf8")
+//                )
                 socket?.send(message: messageData, errorHandler: {
                     eventHandler(.failure(.subscribeFailed($0)))
                 })
@@ -491,9 +491,11 @@ extension NWConnection: GraphQLEnabledSocket {
                 errorHandler(.subscribeFailed(error))
                 
             case .setup:
-                os_log("Setup State Update", log: OSLog.subscription, type: .debug)
+//                os_log("Setup State Update", log: OSLog.subscription, type: .debug)
+                ()
             case .preparing:
-                os_log("Preparing State Update", log: OSLog.subscription, type: .debug)
+//                os_log("Preparing State Update", log: OSLog.subscription, type: .debug)
+                ()
             case .cancelled:
                 os_log("Cancelled State Update", log: OSLog.subscription, type: .debug)
             @unknown default:
@@ -563,12 +565,12 @@ extension URLSessionWebSocketTask: GraphQLEnabledSocket {
     }
     
     public func send(message: Data, errorHandler: @escaping (Error) -> Void) {
-        os_log(
-            "Send data: %{private}@",
-            log: OSLog.subscription,
-            type: .debug,
-            String(data: message, encoding: .utf8) ?? "Invalid Encoding"
-        )
+//        os_log(
+//            "Send data: %{private}@",
+//            log: OSLog.subscription,
+//            type: .debug,
+//            String(data: message, encoding: .utf8) ?? "Invalid Encoding"
+//        )
         self.send(.data(message), completionHandler: {
             if let error = $0 {
                 errorHandler(error)

--- a/Sources/SwiftGraphQL/HTTP.swift
+++ b/Sources/SwiftGraphQL/HTTP.swift
@@ -120,7 +120,7 @@ private func send<Type, TypeLock>(
             } catch let error as HttpError {
                 return completionHandler(.failure(error))
             } catch let error {
-                return completionHandler(.failure(.decodingError(error)))
+                return completionHandler(.failure(.decodingError(error, extensions: nil)))
             }
         }
 
@@ -146,8 +146,8 @@ public enum HttpError: Error {
     case badpayload
     case badstatus
     case cancelled
-    case decodingError(Error)
-    case graphQLErrors([GraphQLError])
+    case decodingError(Error, extensions: [String: AnyCodable]?)
+    case graphQLErrors([GraphQLError], extensions: [String: AnyCodable]?)
 }
 
 extension HttpError: Equatable {

--- a/Sources/SwiftGraphQL/HTTP.swift
+++ b/Sources/SwiftGraphQL/HTTP.swift
@@ -214,8 +214,13 @@ private func createGraphQLRequest<Type, TypeLock>(
     
     #if DEBUG
     #if targetEnvironment(simulator)
+    // Write the query
     let filename = operationName ?? "\(Int(Date().timeIntervalSince1970))"
     try? payload.query.write(toFile: "/tmp/query_\(filename).graphql", atomically: true, encoding: .utf8)
+    // Write the variables
+    if let variables = try? encoder.encode(payload.variables) {
+        try? variables.write(to: URL(fileURLWithPath: "/tmp/query_variables_\(filename).json"))
+    }
     #endif
     #endif
     let encoded = try! encoder.encode(payload)

--- a/Sources/SwiftGraphQL/HTTP.swift
+++ b/Sources/SwiftGraphQL/HTTP.swift
@@ -211,9 +211,11 @@ private func createGraphQLRequest<Type, TypeLock>(
     // Construct HTTP body.
     let encoder = JSONEncoder()
     let payload = selection.buildPayload(operationName: operationName)
+    
     #if DEBUG
     #if targetEnvironment(simulator)
-    try? payload.query.write(toFile: "/tmp/\(operationName ?? "query").graphql", atomically: true, encoding: .utf8)
+    let filename = operationName ?? "\(Int(Date().timeIntervalSince1970))"
+    try? payload.query.write(toFile: "/tmp/query_\(filename).graphql", atomically: true, encoding: .utf8)
     #endif
     #endif
     let encoded = try! encoder.encode(payload)

--- a/Sources/SwiftGraphQL/HTTP.swift
+++ b/Sources/SwiftGraphQL/HTTP.swift
@@ -113,8 +113,15 @@ private func send<Type, TypeLock>(
         }
 
         // Try to serialize the response.
-        if let data = data, let result = try? GraphQLResult(data, with: selection) {
-            return completionHandler(.success(result))
+        if let data = data {
+            do {
+                let result = try GraphQLResult(data, with: selection)
+                return completionHandler(.success(result))
+            } catch let error as HttpError {
+                return completionHandler(.failure(error))
+            } catch let error {
+                return completionHandler(.failure(.decodingError(error)))
+            }
         }
 
         return completionHandler(.failure(.badpayload))
@@ -139,6 +146,7 @@ public enum HttpError: Error {
     case badpayload
     case badstatus
     case cancelled
+    case decodingError(Error)
 }
 
 extension HttpError: Equatable {
@@ -146,9 +154,12 @@ extension HttpError: Equatable {
         // Equals if they are of the same type, different otherwise.
         switch (lhs, rhs) {
         case (.badURL, badURL),
-             (.timeout, .timeout),
-             (.badpayload, .badpayload),
-             (.badstatus, .badstatus):
+            (.timeout, .timeout),
+            (.badpayload, .badpayload),
+            (.badstatus, .badstatus),
+            (.cancelled, .cancelled),
+            (.network, network),
+            (.decodingError, decodingError):
             return true
         default:
             return false

--- a/Sources/SwiftGraphQL/Result.swift
+++ b/Sources/SwiftGraphQL/Result.swift
@@ -5,6 +5,7 @@ import Foundation
 public struct GraphQLResult<Type, TypeLock> {
     public let data: Type
     public let errors: [GraphQLError]?
+    public let extensions: [String: AnyCodable]?
 }
 
 extension GraphQLResult: Equatable where Type: Equatable, TypeLock: Decodable {}
@@ -13,18 +14,21 @@ extension GraphQLResult where TypeLock: Decodable {
     init(_ response: Data, with selection: Selection<Type, TypeLock?>) throws {
         // Decodes the data using provided selection.
         var errors: [GraphQLError]? = nil
+        var extensions: [String: AnyCodable]? = nil
         do {
             let decoder = JSONDecoder()
             let response = try decoder.decode(GraphQLResponse.self, from: response)
             errors = response.errors
+            extensions = response.extensions
             self.data = try selection.decode(data: response.data)
             self.errors = errors
+            self.extensions = extensions
         } catch let error {
             // If we have specific errors, use them
             if let errors = errors, !errors.isEmpty {
-                throw HttpError.graphQLErrors(errors)
+                throw HttpError.graphQLErrors(errors, extensions: extensions)
             } else {
-                throw HttpError.decodingError(error)
+                throw HttpError.decodingError(error, extensions: extensions)
             }
         }
     }
@@ -35,6 +39,7 @@ extension GraphQLResult where TypeLock: Decodable {
             let response: GraphQLResponse = try webSocketMessage.decodePayload()
             self.data = try selection.decode(data: response.data)
             self.errors = response.errors
+            self.extensions = response.extensions
         } catch {
             // Catches all errors and turns them into a bad payload SwiftGraphQL error.
             throw HttpError.badpayload
@@ -45,6 +50,7 @@ extension GraphQLResult where TypeLock: Decodable {
 
     struct GraphQLResponse: Decodable {
         let data: TypeLock?
+        let extensions: [String: AnyCodable]?
         let errors: [GraphQLError]?
     }
 }
@@ -54,7 +60,7 @@ extension GraphQLResult where TypeLock: Decodable {
 public struct GraphQLError: Codable, Equatable {
     public let message: String
     public let locations: [Location]?
-//    public let path: [String]?
+    public let extensions: [String: AnyCodable]?
 
     public struct Location: Codable, Equatable {
         public let line: Int

--- a/Sources/SwiftGraphQL/Result.swift
+++ b/Sources/SwiftGraphQL/Result.swift
@@ -17,9 +17,9 @@ extension GraphQLResult where TypeLock: Decodable {
             let response = try decoder.decode(GraphQLResponse.self, from: response)
             self.data = try selection.decode(data: response.data)
             self.errors = response.errors
-        } catch {
+        } catch let error {
             // Catches all errors and turns them into a bad payload SwiftGraphQL error.
-            throw HttpError.badpayload
+            throw HttpError.decodingError(error)
         }
     }
 
@@ -46,7 +46,7 @@ extension GraphQLResult where TypeLock: Decodable {
 // MARK: - GraphQL Error
 
 public struct GraphQLError: Codable, Equatable {
-    let message: String
+    public let message: String
     public let locations: [Location]?
 //    public let path: [String]?
 


### PR DESCRIPTION
This PR does a couple of things:

- It removes `print` statements in lieu of `os_log` for better integration into the logging ecosystem
- It replaces `try!` force unwrapping in various places in the subscription code with `try?`
- It removes an instance of a `fatalError`
- It makes changes to the GraphQL protocol based on the standard. Before these changes, running it against the GraphQL server [that I tested with](https://github.com/graphql-rust/juniper) would fail. With these changes, subscriptions work correctly. I'm by no means a graphql-subscription expert, so if my changes require additional changes to make it work with other servers, feel free to point that out.
- It adds a (wip) way of connecting to WebSockets via NWNetworking because, according to Apple's authority on
  all things network - Quinn The Eskimo - URLSession based websockets have lots of issues while NWNetworking
  has none: https://developer.apple.com/forums/thread/653599
- It fixes a bug that caused the app to go into an infinite loop draining the users battery as soon as the
  connection to the websocket went away. 
 
As to the protocol issues, I figured out that there're [two competing graphql subscription protocols](https://stackoverflow.com/questions/67659937/what-are-differences-between-graphql-subscription-and-websocket-protocol), `subscriptions-transport-was` and `graphql-ws` with slight incompatibilities (of course!). I might rework this PR to allow choosing which type to connect to.
