### PR TITLE
NSNull case was handled for nullable selections

### DIFF
--- a/Sources/SwiftGraphQL/Selection/Selection+Transform.swift
+++ b/Sources/SwiftGraphQL/Selection/Selection+Transform.swift
@@ -35,7 +35,7 @@ public extension Selection {
             switch fields.__state {
             case let .decoding(data):
                 switch data.value {
-                case is Void:
+                case is Void, is NSNull:
                     return nil
                 default:
                     return try self.__decode(data: data)

--- a/Tests/SwiftGraphQLTests/Selection/SelectionDecodingTests.swift
+++ b/Tests/SwiftGraphQLTests/Selection/SelectionDecodingTests.swift
@@ -47,6 +47,28 @@ final class SelectionDecodingTests: XCTestCase {
         XCTAssertEqual(result.errors, nil)
     }
 
+    func testNullableNSNull() throws {
+        let result: ExecutionResult = """
+            {
+              "data": null
+            }
+            """.execution()
+
+        let selection = Selection<String, String> {
+            switch $0.__state {
+            case let .decoding(data):
+                return try String(from: data)
+            case .selecting:
+                return "wrong"
+            }
+        }
+        let nullableSelection = selection.nullable
+
+        let decoded = try nullableSelection.decode(raw: result.data)
+        XCTAssertEqual(decoded, nil)
+        XCTAssertEqual(result.errors, nil)
+    }
+
     func testList() throws {
         
         let result: ExecutionResult = """


### PR DESCRIPTION
Fix for the https://github.com/maticzav/swift-graphql/issues/89

I've found that value of AnyCodable is Optional<Any> - some : <null> in that cases. It's not nil. So, instead of void, we receive a "value" while decoding and decoder fails
```
(lldb) po value
▿ Optional<Any>
  - some : <null>
 
(lldb) po value == nil
false
```

```
@frozen public struct AnyCodable: Codable {
    public let value: Any

    public init<T>(_ value: T?) {
        self.value = value ?? ()
    }
}
```

But the nullable selection handles only `void` case