### PR TITLE
Fix added combined error and extension

### DIFF
--- a/Sources/GraphQL/Error.swift
+++ b/Sources/GraphQL/Error.swift
@@ -4,7 +4,7 @@ import Foundation
 /// execute phases of performing a GraphQL operation. In addition to a message
 /// and stack trace, it also includes information about the locations in a
 /// GraphQL document and/or execution result that correspond to the Error.
-public struct GraphQLError: Codable, Equatable, Sendable {
+public struct GraphQLError: Codable, Equatable {
     
     /// A short, human-readable summary of the problem.
     public let message: String
@@ -58,17 +58,22 @@ public struct GraphQLError: Codable, Equatable, Sendable {
             }
         }
     }
+
+    /// Reserved entry for implementors to extend the protocol however they see fit.
+    public let extensions: [String: AnyCodable]?
     
     // MARK: - Initializer
 
     public init(
         message: String,
         locations: [Location]? = nil,
-        path: [PathLink]? = nil
+        path: [PathLink]? = nil,
+        extensions: [String: AnyCodable]? = nil
     ) {
         self.message = message
         self.locations = locations
         self.path = path
+        self.extensions = extensions
     }
 }
 

--- a/Sources/SwiftGraphQLClient/Client/Operation.swift
+++ b/Sources/SwiftGraphQLClient/Client/Operation.swift
@@ -105,6 +105,9 @@ public enum CombinedError: Error {
     
     /// An error occured and it's not clear why.
     case unknown(Error)
+
+    /// Combines different kinds of errors into one
+    indirect case combined([CombinedError])
 }
 
 extension CombinedError: Equatable {

--- a/Sources/SwiftGraphQLClient/Client/Selection.swift
+++ b/Sources/SwiftGraphQLClient/Client/Selection.swift
@@ -122,16 +122,26 @@ extension OperationResult {
     fileprivate func decode<T, TypeLock>(
         selection: Selection<T, TypeLock>
     ) throws -> DecodedOperationResult<T> {
-        let data = try selection.decode(raw: self.data)
-        
-        let result = DecodedOperationResult(
-            operation: self.operation,
-            data: data,
-            errors: self.errors,
-            stale: self.stale
-        )
-        
-        return result
+        do {
+            let data = try selection.decode(raw: self.data)
+
+            let result = DecodedOperationResult(
+                operation: self.operation,
+                data: data,
+                errors: self.errors,
+                stale: self.stale
+            )
+
+            return result
+        } catch {
+            if self.errors.isEmpty {
+                throw error
+            } else {
+                var errors = self.errors
+                errors.append(.parsing(error))
+                throw CombinedError.combined(errors)
+            }
+        }
     }
 }
 #endif

--- a/Sources/SwiftGraphQLClient/Client/Selection.swift
+++ b/Sources/SwiftGraphQLClient/Client/Selection.swift
@@ -122,6 +122,10 @@ extension OperationResult {
     fileprivate func decode<T, TypeLock>(
         selection: Selection<T, TypeLock>
     ) throws -> DecodedOperationResult<T> {
+        if self.data == nil && !self.errors.isEmpty {
+          throw CombinedError.combined(errors)
+        }
+
         do {
             let data = try selection.decode(raw: self.data)
 


### PR DESCRIPTION
GraphQL error might have an optional field "extensions" which is a dictionary and might have additional data (like error code).
[http://spec.graphql.org/draft/#sec-Errors.Error-result-format](http://spec.graphql.org/draft/#sec-Errors.Error-result-format)

Also now if there are GraphQL errors they won't be dropped in case of parsing issues

Example: Query asked for some non optional Entity, but requesting user was suspended/deleted, thus GraphQL will deliver something like this:
```
{
   "errors":[
      {
         "message":"The current user is not authorized to access this resource.",
         "locations":[
            {
               "line":2,
               "column":3
            }
         ],
         "path":[
            "userobjectType__1utyewuixim09"
         ],
         "extensions":{
            "code":"AUTH_NOT_AUTHENTICATED"
         }
      }
   ],
   "data":{}
}
```
As you can see data field is empty and as such can't be parsed, thus we should combine parsing error and the one about Auth