### PR TITLE
Bump Package Versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,6 @@ SwiftGraphQL is split into multiple packages that serve different purposes.
 
 This package is best developed using Swift command line tools.
 
-> NOTE: SwiftGraphQL depends on `swift-format` that relies on `SwiftSyntax` that is distributed as part of the Swift toolchain. It's important that you set the correct version of Swift Command Line Tools when developing so that the tools match the version of `swift-format` used.
-
-```sh
-swift package tools-version --set 5.5
-```
-
 
 ## Creating a Pull Request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,6 @@ Hey :wave:! This library is a collaborative effort of many people and we are all
 
 > If you have any questions about the library or just want to share ideas, feel free to reach out to Matic at `matic.zavadlal [at] gmail.com` or `@maticzav` on Twitter.
 
-
 ## Roadmap
 
 Feel free to contribute in any way possible. We are excited about your ideas and want to share them with the rest of the world. It's often even more helpful to write a well documented idea than to write code because ["code is the easy part"](https://www.youtube.com/watch?v=DSjbTC-hvqQ).
@@ -19,7 +18,6 @@ We are currently investing our efforts into
 
 If you decide to contribute in any of these topics, you'll' get a lot of attention and have top priority.
 
-
 ## Code Organization
 
 SwiftGraphQL is split into multiple packages that serve different purposes.
@@ -32,7 +30,6 @@ SwiftGraphQL is split into multiple packages that serve different purposes.
 1. **SwiftGraphQLCLI** exposes a ready to use CLI tool for code generation.
 
 This package is best developed using Swift command line tools.
-
 
 ## Creating a Pull Request
 
@@ -52,9 +49,16 @@ You can test the generators by running
 swift run swift-graphql http://localhost:4000/graphql
 ```
 
-
 ## Building Binary and Documentation
 
 ```sh
 swift build -c release --product swift-graphql --disable-sandbox
+```
+
+You can run the following two scripts to regenerate APIs for both examples.
+
+```sh
+swift run swift-graphql https://api.github.com/graphql --config examples/GitHubStars/swiftgraphql.yml --output examples/GitHubStars/GitHubStars/GraphQL/API.swift  --header "Authorization: bearer TOKEN"
+
+swift run swift-graphql http://localhost:4000/graphql --config examples/thesocialnetwork/ios/TheSocialNetwork/swiftgraphql.yml --output examples/thesocialnetwork/ios/TheSocialNetwork/Shared/GraphQL/API.swift
 ```

--- a/Package.swift
+++ b/Package.swift
@@ -25,12 +25,12 @@ let package = Package(
     dependencies: [
         // .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-format", from: "0.50600.1"),
+        .package(url: "https://github.com/apple/swift-format", branch: "main"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0"),
-        .package(url: "https://github.com/dominicegginton/Spinner", from: "1.0.0"),
+        .package(url: "https://github.com/dominicegginton/Spinner", from: "2.0.0"),
         .package(url: "https://github.com/JohnSundell/Files", from: "4.0.0"),
-        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.4"),
+        .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
     ],
     targets: [
         // Spec

--- a/Sources/SwiftGraphQL/Document/Scalar.swift
+++ b/Sources/SwiftGraphQL/Document/Scalar.swift
@@ -40,7 +40,7 @@ extension Optional: GraphQLScalar where Wrapped: GraphQLScalar {
         case is NSNull:
             self = nil
         #endif
-        case is Void, nil:
+        case is Void:
             self = nil
         case Optional<AnyDecodable>.none:
             self = nil

--- a/Sources/SwiftGraphQLCLI/main.swift
+++ b/Sources/SwiftGraphQLCLI/main.swift
@@ -104,7 +104,7 @@ struct SwiftGraphQLCLI: ParsableCommand {
             SwiftGraphQLCLI.exit(withError: .unreachable)
         }
         
-        loadSchemaSpinner.succeed("Schema loaded!")
+        loadSchemaSpinner.success("Schema loaded!")
 
         // Generate the code.
         let generateCodeSpinner = Spinner(.dots, "Generating API")
@@ -116,14 +116,14 @@ struct SwiftGraphQLCLI: ParsableCommand {
         
         do {
             code = try generator.generate(schema: schema)
-            generateCodeSpinner.succeed("API generated successfully!")
+            generateCodeSpinner.success("API generated successfully!")
         } catch CodegenError.formatting(let err) {
-            generateCodeSpinner.failure(err.localizedDescription)
+            generateCodeSpinner.error(err.localizedDescription)
             SwiftGraphQLCLI.exit(withError: .formatting)
         } catch IntrospectionError.emptyfile, IntrospectionError.unknown {
             SwiftGraphQLCLI.exit(withError: .introspection)
         } catch IntrospectionError.error(let err) {
-            generateCodeSpinner.failure(err.localizedDescription)
+            generateCodeSpinner.error(err.localizedDescription)
             SwiftGraphQLCLI.exit(withError: .introspection)
         } catch {
             SwiftGraphQLCLI.exit(withError: .unknown)
@@ -142,7 +142,7 @@ struct SwiftGraphQLCLI: ParsableCommand {
         // Warn about the unused scalars.
         let ignoredScalars = try schema.missing(from: scalars)
         guard !ignoredScalars.isEmpty else {
-            analyzeSchemaSpinner.succeed("SwiftGraphQL Ready!")
+            analyzeSchemaSpinner.success("SwiftGraphQL Ready!")
             return
         }
         


### PR DESCRIPTION
This PR bumps package versions of `swift-format`, `spinner` and `yams`.

Due to the nature of the new release of `swift-format` (https://github.com/apple/swift-format#matching-swift-format-to-your-swift-version-swift-57-and-earlier), I understand these changes fix #96 and #93.