### PR TITLE
adds support for Swift async API

### DIFF
--- a/Sources/SwiftGraphQLClient/Client/Core.swift
+++ b/Sources/SwiftGraphQLClient/Client/Core.swift
@@ -255,6 +255,15 @@ public class Client: GraphQLClient, ObservableObject {
         
         return self.execute(operation: operation)
     }
+
+    /// Executes a query request with given execution parameters.
+    public func query(
+        _ args: ExecutionArgs,
+        request: URLRequest? = nil,
+        policy: Operation.Policy = .cacheFirst
+    ) async -> OperationResult {
+        await self.query(args, request: request, policy: policy).first()
+    }
     
     /// Executes a mutation request with given execution parameters.
     public func mutate(
@@ -272,6 +281,14 @@ public class Client: GraphQLClient, ObservableObject {
         )
         
         return self.execute(operation: operation)
+    }
+
+    public func mutate(
+        _ args: ExecutionArgs,
+        request: URLRequest? = nil,
+        policy: Operation.Policy = .cacheFirst
+    ) async -> OperationResult {
+        await self.mutate(args, request: request, policy: policy).first()
     }
     
     /// Executes a subscription request with given execution parameters.

--- a/Sources/SwiftGraphQLClient/Client/Selection.swift
+++ b/Sources/SwiftGraphQLClient/Client/Selection.swift
@@ -90,6 +90,17 @@ extension GraphQLClient {
             .tryMap { result in try result.decode(selection: selection) }
             .eraseToAnyPublisher()
     }
+
+
+    /// Executes a query request with given execution parameters.
+    public func query<T, TypeLock>(
+        _ selection: Selection<T, TypeLock>,
+        as operationName: String? = nil,
+        request: URLRequest? = nil,
+        policy: Operation.Policy = .cacheFirst
+    ) async throws -> DecodedOperationResult<T> where TypeLock: GraphQLHttpOperation {
+        try await self.query(selection, as: operationName, request: request, policy: policy).first()
+    }
     
     /// Executes a mutation and returns a stream of decoded values.
     public func mutate<T, TypeLock>(
@@ -101,6 +112,15 @@ extension GraphQLClient {
         self.executeMutation(for: selection, as: operationName, url: request, policy: policy)
             .tryMap { result in try result.decode(selection: selection) }
             .eraseToAnyPublisher()
+    }
+
+    public func mutate<T, TypeLock>(
+        _ selection: Selection<T, TypeLock>,
+        as operationName: String? = nil,
+        request: URLRequest? = nil,
+        policy: Operation.Policy = .cacheFirst
+    ) async throws -> DecodedOperationResult<T> where TypeLock: GraphQLHttpOperation {
+        try await self.mutate(selection, as: operationName, request: request, policy: policy).first()
     }
     
     /// Creates a subscription stream of decoded values from the given query.

--- a/Sources/SwiftGraphQLClient/Extensions/Publishers+Extensions.swift
+++ b/Sources/SwiftGraphQLClient/Extensions/Publishers+Extensions.swift
@@ -8,6 +8,42 @@ extension Publisher {
     func takeUntil<Terminator: Publisher>(_ terminator: Terminator) -> Publishers.TakenUntilPublisher<Self, Terminator> {
         Publishers.TakenUntilPublisher<Self, Terminator>(upstream: self, terminator: terminator)
     }
+
+    /// Takes the first emitted value and completes or throws an error
+    func first() async throws -> Output {
+        try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+
+            cancellable = first()
+                .sink { result in
+                    switch result {
+                    case .finished:
+                        break
+                    case let .failure(error):
+                        continuation.resume(throwing: error)
+                    }
+                    cancellable?.cancel()
+                } receiveValue: { value in
+                    continuation.resume(with: .success(value))
+                }
+        }
+    }
+}
+
+extension Publisher where Failure == Never {
+    /// Takes the first emitted value and completes or throws an error
+    func first() async -> Output {
+        await withCheckedContinuation { continuation in
+            var cancellable: AnyCancellable?
+
+            cancellable = first()
+                .sink { _ in
+                    cancellable?.cancel()
+                } receiveValue: { value in
+                    continuation.resume(with: .success(value))
+                }
+        }
+    }
 }
 
 extension Publishers {

--- a/Tests/SwiftGraphQLClientTests/AsyncClientTests.swift
+++ b/Tests/SwiftGraphQLClientTests/AsyncClientTests.swift
@@ -1,0 +1,125 @@
+import GraphQL
+import SwiftGraphQLClient
+import XCTest
+import Combine
+import SwiftGraphQL
+
+final class AsyncInterfaceTests: XCTestCase {
+    func testAsyncSelectionQueryReturnsValue() async throws {
+        let selection = Selection<String, Objects.User> {
+            try $0.id()
+        }
+
+        let client = MockClient(customExecute: { operation in
+            let id = GraphQLField.leaf(field: "id", parent: "User", arguments: [])
+
+            let user = GraphQLField.composite(
+              field: "user",
+              parent: "Query",
+              type: "User",
+              arguments: [],
+              selection: selection.__selection()
+            )
+
+            let result = OperationResult(
+                operation: operation,
+                data: [
+                    user.alias!: [
+                        id.alias!: "123"
+                    ]
+                ],
+                errors: []
+            )
+            return Just(result).eraseToAnyPublisher()
+        })
+
+
+        let result = try await client.query(Objects.Query.user(selection: selection))
+        XCTAssertEqual(result.data, "123")
+    }
+
+    func testAsyncSelectionQueryThrowsError() async throws {
+        let selection = Selection<String, Objects.User> {
+            try $0.id()
+        }
+
+        let client = MockClient(customExecute: { operation in
+            let result = OperationResult(
+                operation: operation,
+                data: ["unknown_field": "123"],
+                errors: []
+            )
+            return Just(result).eraseToAnyPublisher()
+        })
+
+        await XCTAssertThrowsError(of: ObjectDecodingError.self) {
+            try await client.query(Objects.Query.user(selection: selection))
+        }
+    }
+
+    func testAsyncSelectionMutationReturnsValue() async throws {
+        let selection = Selection.AuthPayload<String?> {
+            try $0.on(
+                authPayloadSuccess: Selection.AuthPayloadSuccess<String?> {
+                    try $0.token()
+                },
+                authPayloadFailure: Selection.AuthPayloadFailure<String?> { _ in
+                    nil
+                }
+            )
+        }
+
+        let client = MockClient(customExecute: { operation in
+            let token = GraphQLField.leaf(field: "token", parent: "AuthPayloadSuccess", arguments: [])
+
+            let auth = GraphQLField.composite(
+              field: "auth",
+              parent: "Mutation",
+              type: "AuthPayload",
+              arguments: [],
+              selection: selection.__selection()
+            )
+
+            let result = OperationResult(
+                operation: operation,
+                data: [
+                    auth.alias!: [
+                        "__typename": "AuthPayloadSuccess",
+                        token.alias!: "123"
+                    ]
+                ],
+                errors: []
+            )
+            return Just(result).eraseToAnyPublisher()
+        })
+
+        let result = try await client.mutate(Objects.Mutation.auth(selection: selection))
+        XCTAssertEqual(result.data, "123")
+    }
+
+    func testAsyncSelectionMutationThrowsError() async throws {
+        let selection = Selection.AuthPayload<String?> {
+            try $0.on(
+                authPayloadSuccess: Selection.AuthPayloadSuccess<String?> {
+                    try $0.token()
+                },
+                authPayloadFailure: Selection.AuthPayloadFailure<String?> { _ in
+                    nil
+                }
+            )
+        }
+
+        let client = MockClient(customExecute: { operation in
+            let result = OperationResult(
+                operation: operation,
+                data: ["unknown_field": "123"],
+                errors: []
+            )
+            return Just(result).eraseToAnyPublisher()
+        })
+
+        await XCTAssertThrowsError(of: ObjectDecodingError.self) {
+            try await client.mutate(Objects.Mutation.auth(selection: selection))
+        }
+    }
+}

--- a/Tests/SwiftGraphQLClientTests/Extensions/Publishers+ExtensionsTests.swift
+++ b/Tests/SwiftGraphQLClientTests/Extensions/Publishers+ExtensionsTests.swift
@@ -116,4 +116,24 @@ final class PublishersExtensionsTests: XCTestCase {
         
         XCTAssertEqual(received, [1])
     }
+
+    func testTakeTheFirstEmittedValueAsynchronously() async throws {
+        let value = await Just(1).first()
+        XCTAssertEqual(value, 1)
+    }
+
+    func testTakeTheFirstEmittedValueAsynchronouslyFromThrowingPublisher() async throws {
+        struct TestError: Error {}
+
+        let value = try await Just(1).setFailureType(to: TestError.self).first()
+        XCTAssertEqual(value, 1)
+    }
+
+    func testThrowEmittedErrorAsynchronously() async throws {
+        struct TestError: Error {}
+
+        await XCTAssertThrowsError(of: TestError.self) {
+            try await Fail<Int, TestError>(error: TestError()).first()
+        }
+    }
 }

--- a/Tests/SwiftGraphQLClientTests/Utils/XCTestHelpers.swift
+++ b/Tests/SwiftGraphQLClientTests/Utils/XCTestHelpers.swift
@@ -1,0 +1,16 @@
+import XCTest
+
+/// Checks whether the provided `body` throws an `error` of the given `error`'s type
+func XCTAssertThrowsError<T: Swift.Error, Output>(
+    of: T.Type,
+    file: StaticString = #file,
+    line: UInt = #line,
+    _ body: () async throws -> Output
+) async {
+    do {
+        _ = try await body()
+        XCTFail("body completed successfully", file: file, line: line)
+    } catch let error {
+        XCTAssertNotNil(error as? T, "Expected error of \(T.self), got \(type(of: error))")
+    }
+}


### PR DESCRIPTION
Adds support for Swift async/await as discussed in https://github.com/maticzav/swift-graphql/issues/51#issuecomment-1229222662

I also skipped async analogue for `subscribe` methods. Such methods have awkward result types like `AsyncThrowingPublisher<AnyPublisher<DecodedOperationResult<T>, any Error>>`.

Thus, I think it's more handy to just use Combine's "native" async binding `.values` for the returned publisher:

```swift
let subscription = try client.subscribe(to: Objects.Subscription.time())

for try await time in subscription.values {
     print(time)
}
```
