### PR TITLE
Fix a typo in the podspec file

### DIFF
--- a/SwiftGraphQL.podspec
+++ b/SwiftGraphQL.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |spec|
 
   spec.source_files  = "Sources/**/*.swift"
 
-	s.deprecated = true
-  s.deprecated_in_favor_of = "Swift Package Manager"
+  spec.deprecated = true
+  spec.deprecated_in_favor_of = "Swift Package Manager"
 end


### PR DESCRIPTION
There was a typo for the deprecated and deprecated_in_favor_of properties that caused an issue when running pod install. I suggest a release type of patch for this update. 