### PR TITLE
feat: change public for Custom FetchExchange

### DIFF
--- a/Sources/SwiftGraphQLClient/Exchanges/ErrorExchange.swift
+++ b/Sources/SwiftGraphQLClient/Exchanges/ErrorExchange.swift
@@ -2,7 +2,7 @@ import Combine
 import Foundation
 
 /// An exchange that lets you listen to errors happening in the execution pipeline.
-struct ErrorExchange: Exchange {
+public struct ErrorExchange: Exchange {
     
     /// Callback function that the exchange calls for every error in the operation result.
     private var onError: (CombinedError, Operation) -> Void

--- a/Sources/SwiftGraphQLClient/Extensions/Publishers+Extensions.swift
+++ b/Sources/SwiftGraphQLClient/Extensions/Publishers+Extensions.swift
@@ -5,7 +5,7 @@ import Foundation
 
 extension Publisher {
     /// Takes upstream values until predicates a value.
-    func takeUntil<Terminator: Publisher>(_ terminator: Terminator) -> Publishers.TakenUntilPublisher<Self, Terminator> {
+    public func takeUntil<Terminator: Publisher>(_ terminator: Terminator) -> Publishers.TakenUntilPublisher<Self, Terminator> {
         Publishers.TakenUntilPublisher<Self, Terminator>(upstream: self, terminator: terminator)
     }
 }
@@ -13,9 +13,9 @@ extension Publisher {
 extension Publishers {
     
     /// A subscriber that takes upstream values until terminator emits a value.
-    struct TakenUntilPublisher<Upstream: Publisher, Terminator: Publisher>: Publisher {
-        typealias Output = Upstream.Output
-        typealias Failure = Upstream.Failure
+    public struct TakenUntilPublisher<Upstream: Publisher, Terminator: Publisher>: Publisher {
+        public typealias Output = Upstream.Output
+        public typealias Failure = Upstream.Failure
         
         /// A function that tells whether the condition is met.
         private var terminator: Terminator
@@ -25,14 +25,14 @@ extension Publishers {
         
         // MARK: - Initializer
         
-        init(upstream: Upstream, terminator: Terminator) {
+        public init(upstream: Upstream, terminator: Terminator) {
             self.upstream = upstream
             self.terminator = terminator
         }
         
         // MARK: - Publisher
         
-        func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
+        public func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
             
             // Wraps the actual subscriber inside a custom subscribers
             // and subscribes to the upstream publisher with it.


### PR DESCRIPTION
This custom FetchExchange can using for "no data key" case.

```swift

public struct MyExecutionResult: Equatable, Encodable, Decodable {
    
    /// Result of a successfull execution of a query.
    public var data: AnyCodable?
    
    /// Any errors that occurred during the GraphQL execution of the server.
    public var errors: [GraphQLError]?
    
    /// Optional parameter indicating that there are more values following this one.
    public var hasNext: Bool?
    
    /// Reserved entry for implementors to extend the protocol however they see fit.
    public let extensions: [String: AnyCodable]?
    
    public init(
        data: AnyCodable,
        errors: [GraphQLError]? = nil,
        hasNext: Bool? = nil,
        extensions: [String: AnyCodable]? = nil
    ) {
        self.data = data
        self.errors = errors
        self.hasNext = hasNext
        self.extensions = extensions
    }
}

public class MyFetchExchange: Exchange {
    
    
    /// Structure used to connect to the server.
    private var session: FetchSession
    
    /// Shared decoder that's used to decode server responses.
    private var decoder: JSONDecoder
    
    /// Shared encoder that's used to encode request body.
    private var encoder: JSONEncoder
    
    // MARK: - Initializer
    
    public init(
        session: FetchSession = URLSession.shared,
        encoder: JSONEncoder = JSONEncoder(),
        decoder: JSONDecoder = JSONDecoder()
    ) {
        self.session = session
        self.encoder = encoder
        self.decoder = decoder
    }
    
    // MARK: - Methods
    public func register(
        client: SwiftGraphQLClient.GraphQLClient,
        operations: AnyPublisher<SwiftGraphQLClient.Operation, Never>,
        next: https://github.com/escaping SwiftGraphQLClient.ExchangeIO
    ) -> AnyPublisher<SwiftGraphQLClient.OperationResult, Never> {
        let shared = operations.share()
        
        let downstream = shared
            .filter { operation in
                operation.kind != .query && operation.kind != .mutation
            }
            .eraseToAnyPublisher()
        
        let upstream = next(downstream)
        
        let fetchstream = shared
            .filter({ $0.kind == .query || $0.kind == .mutation })
            .flatMap({ operation -> AnyPublisher<OperationResult, Never> in
                let body = try! self.encoder.encode(operation.args)
                
                let torndown = shared
                    .filter { $0.kind == .teardown && $0.id == operation.id }
                    .eraseToAnyPublisher()
                
                let publisher = self.session
                    .dataTaskPublisher(for: operation.request, with: body)
                    // NOTE: If the client emits the teardown event, we want to clear up
                    //  the initialised source to prevent memory laeks.
                    .takeUntil(torndown)
                    // NOTE: Unlike WebSocketExchange that emits completion when the stream is over,
                    //  fetch response send completion once it has received all the data. Cancelling
                    //  the pipeline then, would prevent updates from exchange in the future, that's
                    //  why we don't cancel it.
                    .map { (data, response) -> OperationResult in
                        do {
                            var result = try self.decoder.decode(MyExecutionResult.self, from: data)
                            
                            if result.data == nil {
                                result.data = [:]
                            }
                            
                            if let errors = result.errors {
                                return OperationResult(
                                    operation: operation,
                                    data: result.data!,
                                    errors: [.graphql(errors)],
                                    stale: false
                                )
                            }
                            
                            return OperationResult(operation: operation, data: result.data!, errors: [], stale: false)
                        } catch(let err) {
                            return OperationResult(
                                operation: operation,
                                data: AnyCodable(()),
                                errors: [.parsing(err)],
                                stale: false
                            )
                        }
                    }
                    .catch { (error: URLError) -> AnyPublisher<OperationResult, Never> in
                        let result = OperationResult(
                            operation: operation,
                            data: nil,
                            errors: [.network(error)],
                            stale: false
                        )
                        
                        return Just(result).eraseToAnyPublisher()
                    }
                    .eraseToAnyPublisher()
                
                return publisher
            })
        
        return fetchstream.merge(with: upstream).eraseToAnyPublisher()
    }

}

```