### PR TITLE
Set swift-format to v508.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         // .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-format", branch: "main"),
+        .package(url: "https://github.com/apple/swift-format", from: "508.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0"),
         .package(url: "https://github.com/dominicegginton/Spinner", from: "2.0.0"),


### PR DESCRIPTION
_In this PR:_

Solves issue: https://github.com/maticzav/swift-graphql/issues/119

_My machine:_
```sh
$ swift --version

swift-driver version: 1.75.2 Apple Swift version 5.8 (swiftlang-5.8.0.124.2 clang-1403.0.22.11.100)
Target: arm64-apple-macosx13.0
```

```sh
$ swift-format --version

508.0.0
```