### PR TITLE
Retain leading underscores in enum case names

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         // .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-format", branch: "main"),
+        .package(url: "https://github.com/apple/swift-format", from: "508.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0"),
         .package(url: "https://github.com/dominicegginton/Spinner", from: "2.0.0"),

--- a/Sources/SwiftGraphQLCodegen/Generator/Enum.swift
+++ b/Sources/SwiftGraphQLCodegen/Generator/Enum.swift
@@ -70,7 +70,7 @@ extension EnumValue {
     fileprivate var declaration: String {
         """
         \(docs)
-        case \(name.camelCase.normalize.prependUnderscoreIfInt) = "\(name)"
+        case \(name.camelCase(keepPrependedUnderscore: true).normalize) = "\(name)"
         """
     }
 

--- a/Sources/SwiftGraphQLCodegen/Generator/Enum.swift
+++ b/Sources/SwiftGraphQLCodegen/Generator/Enum.swift
@@ -70,7 +70,7 @@ extension EnumValue {
     fileprivate var declaration: String {
         """
         \(docs)
-        case \(name.camelCase.normalize) = "\(name)"
+        case \(name.camelCase.normalize.prependUnderscoreIfInt) = "\(name)"
         """
     }
 

--- a/Sources/SwiftGraphQLUtils/Extensions/String+Case.swift
+++ b/Sources/SwiftGraphQLUtils/Extensions/String+Case.swift
@@ -79,18 +79,17 @@ extension String {
         return pascal[pascal.startIndex].lowercased() + pascal.dropFirst()
     }
 
+	 public func camelCase(keepPrependedUnderscore: Bool) -> String {
+		var result = camelCase
+		if self.prefix(1) == "_" {
+		  result = "_" + result
+		}
+		return result
+	 }
 
     /// Returns if the string is an integer or not
     var isInt: Bool {
         return Int(self) != nil
-    }
-
-    /// Returns the string with an underscore prepended if the string is an integer.
-    public var prependUnderscoreIfInt: String {
-        if self.isInt {
-            return "_\(self)"
-        }
-        return self
     }
 
 }

--- a/Sources/SwiftGraphQLUtils/Extensions/String+Case.swift
+++ b/Sources/SwiftGraphQLUtils/Extensions/String+Case.swift
@@ -78,4 +78,19 @@ extension String {
         let pascal = pascalCase
         return pascal[pascal.startIndex].lowercased() + pascal.dropFirst()
     }
+
+
+    /// Returns if the string is an integer or not
+    var isInt: Bool {
+        return Int(self) != nil
+    }
+
+    /// Returns the string with an underscore prepended if the string is an integer.
+    public var prependUnderscoreIfInt: String {
+        if self.isInt {
+            return "_\(self)"
+        }
+        return self
+    }
+
 }

--- a/Tests/SwiftGraphQLCodegenTests/Generator/EnumTests.swift
+++ b/Tests/SwiftGraphQLCodegenTests/Generator/EnumTests.swift
@@ -30,13 +30,14 @@ final class EnumTests: XCTestCase {
                     deprecationReason: "Was too good."
                 ),
                 EnumValue(
-                    name: "SKYWALKER",
-                    description: nil,
-                    isDeprecated: true,
+                    name: "_SKYWALKER",
+                    description: "Test of prepended underscore.",
+                    isDeprecated: false,
                     deprecationReason: nil
                 ),
             ]
         )
+
 
         let generated = try type.declaration.format()
 
@@ -52,8 +53,8 @@ final class EnumTests: XCTestCase {
                case empire = "EMPIRE"
                /// Released in 1983.
                case jedi = "JEDI"
-           
-               case skywalker = "SKYWALKER"
+               /// Test of prepended underscore.
+               case _skywalker = "_SKYWALKER"
              }
            }
            


### PR DESCRIPTION
Running the Codegen on our GraphQL endpoint failed with the error:
```sh
The operation couldn’t be completed. (SwiftFormat.SwiftFormatError error 2.)
Error: There was an error formatting the code. Make sure your Swift version (i.e. `swift-format`) matches the `swift-format` version. If you need any help, don't hesitate to open an issue and include the log above!
```


I did some investigation and found out it was because the generated enums contained integers as identifiers yielding the error:
```sh
Identifier can only start with a letter or underscore, not a number
```

The generated code looks like this:
```swift
extension Enums {
    /// CDLType
    public enum CdlType: String, CaseIterable, Codable {

case unknown = "UNKNOWN"

case a = "A"

case az = "AZ"

case b = "B"

case c = "C"

case d = "D"

case e = "E"

case 1 = "_1"

case 2 = "_2"

case 3 = "_3"

case 4 = "_4"

case 5 = "_5"

case unrecognized = "UNRECOGNIZED"
    }
}
```

This PR checks if the identifier is an integer and will prepend an underscore if it is, resulting in:
```swift
extension Enums {
    /// CDLType
    public enum CdlType: String, CaseIterable, Codable {

case unknown = "UNKNOWN"

case a = "A"

case az = "AZ"

case b = "B"

case c = "C"

case d = "D"

case e = "E"

case _1 = "_1"

case _2 = "_2"

case _3 = "_3"

case _4 = "_4"

case _5 = "_5"

case unrecognized = "UNRECOGNIZED"
    }
}
```

Now, I don't know if my solution is any good - I am very new to Swift. Any feedback is appreciated.