### PR TITLE
Fix Wrapped Scalar and Coerced Float Decoding, Add `extensions` to GraphQLError

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -2,6 +2,8 @@ name: Migrate TheSocialNetwork Database
 
 on:
   push:
+    paths:
+      - 'examples/thesocialnetwork/prisma/**'
     branches:
       - main
 
@@ -17,10 +19,10 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16.x'
-          
+
       - name: Install dependencies
         run: yarn workspaces focus tsn-server
-        
+
       - name: Deploy Migration
         run: yarn workspace tsn-server deploy
         env:

--- a/Sources/GraphQL/AnyCodable/AnyDecodable.swift
+++ b/Sources/GraphQL/AnyCodable/AnyDecodable.swift
@@ -71,8 +71,10 @@ extension _AnyDecodable {
         } else if let string = try? container.decode(String.self) {
             self.init(string)
         } else if let array = try? container.decode([AnyDecodable].self) {
+            // NOTE: This line manually unwrapps nested AnyCodable values into a flattened `AnyCodable` value (e.g. `AnyCodable([AnyCodable("A"), AnyCodable("B")` into `AnyCodable(["A", "B"]).
             self.init(array.map { $0.value })
         } else if let dictionary = try? container.decode([String: AnyDecodable].self) {
+            // NOTE: This line manually unwrapps nested AnyCodable values into a flattened `AnyCodable` value.
             self.init(dictionary.mapValues { $0.value })
         } else {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyDecodable value cannot be decoded")

--- a/Sources/GraphQL/Error.swift
+++ b/Sources/GraphQL/Error.swift
@@ -1,10 +1,9 @@
 import Foundation
 
-/// A GraphQLError describes an Error found during the parse, validate, or
-/// execute phases of performing a GraphQL operation. In addition to a message
-/// and stack trace, it also includes information about the locations in a
-/// GraphQL document and/or execution result that correspond to the Error.
-public struct GraphQLError: Codable, Equatable, Sendable {
+/// A GraphQLError describes an Error found during the parse, validate, or execute phases of performing a GraphQL operation. In addition to a message and stack trace, it also includes information about the locations in a GraphQL document and/or execution result that correspond to the Error.
+///
+/// Its implementation follows the specification described at [GraphQLSpec](http://spec.graphql.org/October2021/#sec-Errors.Error-result-format).
+public struct GraphQLError: Codable, Equatable {
     
     /// A short, human-readable summary of the problem.
     public let message: String
@@ -59,16 +58,21 @@ public struct GraphQLError: Codable, Equatable, Sendable {
         }
     }
     
+    /// A map of strings for implementors to add additional information to errors however they see fit, and there are no additional restrictions on its contents.
+    public let extensions: [String: AnyCodable]?
+    
     // MARK: - Initializer
 
     public init(
         message: String,
         locations: [Location]? = nil,
-        path: [PathLink]? = nil
+        path: [PathLink]? = nil,
+        extensions: [String: AnyCodable]? = nil
     ) {
         self.message = message
         self.locations = locations
         self.path = path
+        self.extensions = extensions
     }
 }
 

--- a/Sources/SwiftGraphQLClient/Client/Config.swift
+++ b/Sources/SwiftGraphQLClient/Client/Config.swift
@@ -7,5 +7,8 @@ public class ClientConfiguration {
     /// Logger that we use to communitcate state changes and events inside the client.
     open var logger: Logger = Logger(label: "graphql.client")
     
-    public init() {}
+    public init() {
+        // Certain built-in exchanges (e.g. `DebugExchange`) product `.debug` logs that require `.debug` log level to be visible. This makes sure that the expected functionality of all exchanges matches the actual functionality (e.g. "debug exchange actually prints messages in the console").
+        self.logger.logLevel = .debug
+    }
 }

--- a/Sources/SwiftGraphQLClient/Exchanges/DebugExchange.swift
+++ b/Sources/SwiftGraphQLClient/Exchanges/DebugExchange.swift
@@ -3,6 +3,16 @@ import Foundation
 import GraphQL
 
 /// Exchange that logs operations going down- and results going up-stream.
+///
+/// - NOTE: `DebugExchange` assumes that the logger level of the client is set to `.debug`. Otherwise, the logs might not appear in the stream.
+///
+/// ```swift
+/// // chaning the client logger level
+/// var config = SwiftGraphQLClient.ClientConfiguration()
+/// config.logger.logLevel = .debug
+///
+/// SwiftGraphQLClient.Client(request: request, exchanges: exchanges, config: config)
+/// ```
 public struct DebugExchange: Exchange {
     
     /// Tells whether the client is in a development environment of not.

--- a/Tests/SwiftGraphQLTests/Selection/SelectionDecodingTests.swift
+++ b/Tests/SwiftGraphQLTests/Selection/SelectionDecodingTests.swift
@@ -68,9 +68,30 @@ final class SelectionDecodingTests: XCTestCase {
         XCTAssertEqual(decoded, nil)
         XCTAssertEqual(result.errors, nil)
     }
+    
+    func testCoercedFloats() throws {
+        let result: ExecutionResult = """
+            {
+              "data": 0
+            }
+            """.execution()
 
-    func testList() throws {
-        
+        let selection = Selection<Double, Double> {
+            switch $0.__state {
+            case let .decoding(data):
+                return try Double(from: data)
+            case .selecting:
+                return 42
+            }
+        }
+        let nullableSelection = selection.nullable
+
+        let decoded = try nullableSelection.decode(raw: result.data)
+        XCTAssertEqual(decoded, 0)
+        XCTAssertEqual(result.errors, nil)
+    }
+
+    func testListOfInts() throws {
         let result: ExecutionResult = """
             {
               "data": [1, 2, 3]
@@ -88,6 +109,70 @@ final class SelectionDecodingTests: XCTestCase {
 
         let decoded = try selection.list.decode(raw: result.data)
         XCTAssertEqual(decoded, [1, 2, 3])
+        XCTAssertEqual(result.errors, nil)
+    }
+    
+    func testListOfCoercedFloats() throws {
+        let result: ExecutionResult = """
+            {
+              "data": [1, 2, 3]
+            }
+            """.execution()
+        
+        let selection = Selection<Double, Double> {
+            switch $0.__state {
+            case let .decoding(data):
+                return try Double(from: data)
+            case .selecting:
+                return 0
+            }
+        }
+
+        let decoded = try selection.list.decode(raw: result.data)
+        XCTAssertEqual(decoded, [1, 2, 3])
+        XCTAssertEqual(result.errors, nil)
+    }
+    
+    func testListOfStrings() throws {
+        let result: ExecutionResult = """
+            {
+                "data": ["John", "Tom"]
+            }
+            """.execution()
+
+        let selection = Selection<String, String> {
+            switch $0.__state {
+            case let .decoding(data):
+                return try String(from: data)
+            case .selecting:
+                return "wrong"
+            }
+        }
+
+        let decoded = try selection.list.decode(raw: result.data)
+        XCTAssertEqual(decoded, ["John", "Tom"])
+        XCTAssertEqual(result.errors, nil)
+    }
+    
+    func testListOfLiteralStrings() throws {
+        // NOTE: This is a different test than the one above. SwiftGraphQL generates an "in-place decoder" for a list of scalars (i.e. you should do `.list()`, not `field.list.nullable.list.string`).
+        let result: ExecutionResult = """
+            {
+                "data": ["John", "Tom"]
+            }
+            """.execution()
+
+        let selection = Selection<[String], [String]> {
+            switch $0.__state {
+            case let .decoding(data):
+                return try [String](from: data)
+            case .selecting:
+                return []
+            }
+        }
+
+        let decoded = try selection.decode(raw: result.data)
+        XCTAssertEqual(decoded, ["John", "Tom"])
         XCTAssertEqual(result.errors, nil)
     }
     


### PR DESCRIPTION
This PR fixes the bug where coerced `Float` values would throw an error. Additionally, it fixes the bug where wrapped scalar values (e.g. `[Array]`) would throw in decoding step because the decoder expected them to be nested `AnyCodable` values and in reality they were flattened `AnyCodable` values.

Lastly, this PR changes the default logging level so that `DebugExchange` prints messages in the console without any extra configuration.

Fixes #120.
Fixes #121.
Fixes #117.

Huge thanks to [@NeverwinterMoon](https://github.com/NeverwinterMoon), [@tuxi7x](https://github.com/tuxi7x) and [@nordfogel](https://github.com/nordfogel). I genuinely can't thank you enough for your effort. This library is much better because of your contribution and I am thankful to have such a great community surrounding the library.