### PR TITLE
Fix Error Handling Behaviour

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push: {}
   pull_request: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   test:
     name: Test Sources

--- a/Sources/SwiftGraphQLClient/Client/Operation.swift
+++ b/Sources/SwiftGraphQLClient/Client/Operation.swift
@@ -86,7 +86,7 @@ public struct OperationResult: Equatable {
     /// Execution error encontered in one of the exchanges in the chain.
     ///
     /// When we use a GraphQL API there are two kinds of errors we may encounter: Network Errors and GraphQL Errors from the API. Since it's common to encounter either of them, there's a CombinedError class that can hold and abstract either.
-    public var error: ExecutionError?
+    public var error: CombinedError?
     
     /// Optional stale flag added by exchanges that return stale results.
     public var stale: Bool?
@@ -94,7 +94,7 @@ public struct OperationResult: Equatable {
     public init(
         operation: Operation,
         data: AnyCodable,
-        error: ExecutionError? = nil,
+        error: CombinedError? = nil,
         stale: Bool? = nil
     ) {
         self.operation = operation
@@ -106,7 +106,7 @@ public struct OperationResult: Equatable {
 
 
 /// An error structure describing an error that may have happened in one of the exchanges.
-public enum ExecutionError: Error {
+public enum CombinedError: Error {
     
     /// Describes an error that occured on the networking layer.
     case network(URLError)
@@ -118,8 +118,8 @@ public enum ExecutionError: Error {
     case unknown(Error)
 }
 
-extension ExecutionError: Equatable {
-    public static func == (lhs: ExecutionError, rhs: ExecutionError) -> Bool {
+extension CombinedError: Equatable {
+    public static func == (lhs: CombinedError, rhs: CombinedError) -> Bool {
         switch (lhs, rhs) {
         case let (.graphql(l), .graphql(r)):
             return l == r
@@ -162,7 +162,7 @@ public struct DecodedOperationResult<T> {
     public var data: T
     
     /// Execution error encountered in one of the exchanges.
-    public var error: ExecutionError?
+    public var error: CombinedError?
     
     /// Tells wether the result of the query is ot up-to-date.
     public var stale: Bool?

--- a/Sources/SwiftGraphQLClient/Exchanges/CacheExchange.swift
+++ b/Sources/SwiftGraphQLClient/Exchanges/CacheExchange.swift
@@ -113,7 +113,7 @@ public class CacheExchange: Exchange {
                 
                 // Cache query result and operation references.
                 // (AnyCodable represents nil values as Void objects.)
-                if result.operation.kind == .query, result.errors.isEmpty {
+                if result.operation.kind == .query, result.error == nil {
                     self.resultCache[result.operation.id] = result
                     
                     // NOTE: cache-only operations never receive data from the

--- a/Sources/SwiftGraphQLClient/Exchanges/ErrorExchange.swift
+++ b/Sources/SwiftGraphQLClient/Exchanges/ErrorExchange.swift
@@ -5,9 +5,9 @@ import Foundation
 public struct ErrorExchange: Exchange {
     
     /// Callback function that the exchange calls for every error in the operation result.
-    private var onError: (ExecutionError, Operation) -> Void
+    private var onError: (CombinedError, Operation) -> Void
     
-    public init(onError: @escaping (ExecutionError, Operation) -> Void) {
+    public init(onError: @escaping (CombinedError, Operation) -> Void) {
         self.onError = onError
     }
     

--- a/Sources/SwiftGraphQLClient/Exchanges/ErrorExchange.swift
+++ b/Sources/SwiftGraphQLClient/Exchanges/ErrorExchange.swift
@@ -5,9 +5,9 @@ import Foundation
 public struct ErrorExchange: Exchange {
     
     /// Callback function that the exchange calls for every error in the operation result.
-    private var onError: (CombinedError, Operation) -> Void
+    private var onError: (ExecutionError, Operation) -> Void
     
-    public init(onError: @escaping (CombinedError, Operation) -> Void) {
+    public init(onError: @escaping (ExecutionError, Operation) -> Void) {
         self.onError = onError
     }
     
@@ -20,7 +20,7 @@ public struct ErrorExchange: Exchange {
     ) -> AnyPublisher<OperationResult, Never> {
         next(operations)
             .handleEvents(receiveOutput: { result in
-                for error in result.errors {
+                if let error = result.error {
                     self.onError(error, result.operation)
                 }
             })

--- a/Sources/SwiftGraphQLClient/Exchanges/FetchExchange.swift
+++ b/Sources/SwiftGraphQLClient/Exchanges/FetchExchange.swift
@@ -86,17 +86,22 @@ public class FetchExchange: Exchange {
                                 return OperationResult(
                                     operation: operation,
                                     data: result.data,
-                                    errors: [.graphql(errors)],
+                                    error: .graphql(errors),
                                     stale: false
                                 )
                             }
                             
-                            return OperationResult(operation: operation, data: result.data, errors: [], stale: false)
+                            return OperationResult(
+                                operation: operation,
+                                data: result.data,
+                                error: nil,
+                                stale: false
+                            )
                         } catch(let err) {
                             return OperationResult(
                                 operation: operation,
                                 data: AnyCodable(()),
-                                errors: [.parsing(err)],
+                                error: .unknown(err),
                                 stale: false
                             )
                         }
@@ -105,7 +110,7 @@ public class FetchExchange: Exchange {
                         let result = OperationResult(
                             operation: operation,
                             data: nil,
-                            errors: [.network(error)],
+                            error: .network(error),
                             stale: false
                         )
                         

--- a/Sources/SwiftGraphQLClient/Exchanges/WebSocketExchange.swift
+++ b/Sources/SwiftGraphQLClient/Exchanges/WebSocketExchange.swift
@@ -60,12 +60,12 @@ public class WebSocketExchange: Exchange {
                 var op = OperationResult(
                     operation: operation,
                     data: exec.data,
-                    errors: [],
+                    error: nil,
                     stale: false
                 )
                 
                 if let errors = exec.errors {
-                    op.errors = [.graphql(errors)]
+                    op.error = .graphql(errors)
                 }
                 return op
             }

--- a/Tests/SwiftGraphQLClientTests/Exchanges/CacheExchangeTests.swift
+++ b/Tests/SwiftGraphQLClientTests/Exchanges/CacheExchangeTests.swift
@@ -113,7 +113,7 @@ final class CacheExchangeTests: XCTestCase {
             results.send(SwiftGraphQLClient.OperationResult(
                 operation: op,
                 data: AnyCodable("hello"),
-                errors: [],
+                error: nil,
                 stale: false
             ))
             operations.send(op)
@@ -136,14 +136,14 @@ final class CacheExchangeTests: XCTestCase {
             results.send(SwiftGraphQLClient.OperationResult(
                 operation: op,
                 data: AnyCodable("hello"),
-                errors: [],
+                error: nil,
                 stale: false
             ))
             operations.send(op)
             results.send(SwiftGraphQLClient.OperationResult(
                 operation: op,
                 data: AnyCodable("world"),
-                errors: [],
+                error: nil,
                 stale: false
             ))
         }
@@ -175,7 +175,7 @@ final class CacheExchangeTests: XCTestCase {
             results.send(SwiftGraphQLClient.OperationResult(
                 operation: op,
                 data: AnyCodable("hello"),
-                errors: [],
+                error: nil,
                 stale: false
             ))
             
@@ -201,7 +201,7 @@ final class CacheExchangeTests: XCTestCase {
             results.send(SwiftGraphQLClient.OperationResult(
                 operation: op,
                 data: AnyCodable("hello"),
-                errors: [],
+                error: nil,
                 stale: false
             ))
             
@@ -243,7 +243,7 @@ final class CacheExchangeTests: XCTestCase {
             results.send(SwiftGraphQLClient.OperationResult(
                 operation: op,
                 data: AnyCodable("hello"),
-                errors: [],
+                error: nil,
                 stale: false
             ))
             
@@ -251,7 +251,7 @@ final class CacheExchangeTests: XCTestCase {
             results.send(SwiftGraphQLClient.OperationResult(
                 operation: CacheExchangeTests.mutationOperation,
                 data: AnyCodable("much data"),
-                errors: [],
+                error: nil,
                 stale: false
             ))
         }

--- a/Tests/SwiftGraphQLClientTests/Exchanges/ComposeExchangeTests.swift
+++ b/Tests/SwiftGraphQLClientTests/Exchanges/ComposeExchangeTests.swift
@@ -58,7 +58,7 @@ final class ComposeExchangeTests: XCTestCase {
                         SwiftGraphQLClient.OperationResult(
                             operation: operation,
                             data: nil,
-                            errors: [],
+                            error: nil,
                             stale: false
                         )
                     }

--- a/Tests/SwiftGraphQLClientTests/Exchanges/DedupExchangeTests.swift
+++ b/Tests/SwiftGraphQLClientTests/Exchanges/DedupExchangeTests.swift
@@ -98,7 +98,7 @@ final class DedupExchangeTests: XCTestCase {
             results.send(SwiftGraphQLClient.OperationResult(
                 operation: DedupExchangeTests.queryOperation,
                 data: nil,
-                errors: [],
+                error: nil,
                 stale: false
             ))
             operations.send(DedupExchangeTests.queryOperation)

--- a/Tests/SwiftGraphQLClientTests/Exchanges/FetchExchangeTests.swift
+++ b/Tests/SwiftGraphQLClientTests/Exchanges/FetchExchangeTests.swift
@@ -89,7 +89,7 @@ final class FetchExchangeTests: XCTestCase {
             XCTAssertEqual(result, OperationResult(
                 operation: result.operation,
                 data: AnyCodable("hello"),
-                errors: [],
+                error: nil,
                 stale: false)
             )
             
@@ -126,13 +126,14 @@ final class FetchExchangeTests: XCTestCase {
             return downstream
         }
         .sink { result in
-            XCTAssertEqual(result, OperationResult(
-                operation: result.operation,
-                data: nil,
-                errors: [
-                    .network(URLError(rawValue: 400))
-                ],
-                stale: false)
+            XCTAssertEqual(
+                result,
+                OperationResult(
+                    operation: result.operation,
+                    data: nil,
+                    error: .network(URLError(rawValue: 400)),
+                    stale: false
+                )
             )
             
             expectation.fulfill()

--- a/website/docs/errors.mdx
+++ b/website/docs/errors.mdx
@@ -1,0 +1,50 @@
+---
+title: Handling Errors
+sidebar_label: Error Handling
+---
+
+When you submit a query, mutation or a subscription to your GraphQL server one of the following things might happen:
+
+1. the request was successful,
+1. your request encountered an error,
+1. your request encountered an error but could still produce a result.
+
+In both the first and the third case, your GraphQL server is going to conform to your schema - certain fields may have null values instead of the expected data, but the shape of the response will match the expected one.
+
+In the second case, on the other hand, GraphQL encountered a "terminating error" meaning that it could not produce a result that would conform to your schema (e.g. a non-nullable field was null). In this case, GraphQL will _not_ return a result at all.
+
+Since SwiftGraphQL uses the schema as the single source of truth, handling the first and the third case is easy. Handling the second case, however, requires some additional work.
+
+## Operation Result Errors vs Throwables
+
+Because Swift is a compiled, statically typed language, we need to be explicit about every type conversion happening in our code. To make sure developer experience doesn't suffer, SwiftGraphQL produces a terminating error when it encounters a diviation from the schema and produces a `DecodedOperationResult` in other cases.
+
+```swift
+let query = Selection.Query<String> {
+	try $0.hello()
+}
+
+// General result callback.
+client.query(query)
+	.sink { completion in
+		switch (completion) {
+		case .failure(let error):
+			// Handle a terminating error.
+		case .finished:
+			()
+		}
+
+	} receiveValue: { (result: DecodedOperationResult) in
+		// Handle a successful or partial result.
+	}
+```
+
+> You can read more about error handling in [The Swift Programming Language](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/errorhandling#Handling-Errors-Using-Do-Catch).
+
+## Combined Errors
+
+> CombinedError pattern is heavily inspired by [urql](https://formidable.com/open-source/urql/docs/basics/errors/) client. I suggest you check their documentation for any further explanations.
+
+When we use a GraphQL API there are two kinds of errors we may encounter: Network Errors and GraphQL Errors from the API. Since it's common to encounter either of them, there's a CombinedError class that can hold and abstract either.
+
+> It's worth noting that an error can coexist and be returned in a successful request alongside data. This is because in GraphQL a query can have partially failed but still contain some data.

--- a/website/routes.ts
+++ b/website/routes.ts
@@ -13,6 +13,7 @@ export function getRoutes(): IRoutes {
           'network',
           'querying',
           'subscriptions',
+          'errors',
           'guides',
           'advanced',
           'faq',


### PR DESCRIPTION
This PR fixes an issue where a response containing errors and no data would fail if the selection expected a non-null field. I wrongly assumed that if the error may be raised, it's going to only be raised with nullable fields. In reality, that assumption is wrong and the client should be able to handle a faulty response regardless of the GraphQL schema.

This PR is a breaking change that changes the error type of the client interface.

This PR is related to #99 which served as a basis for this PR. Even though I created a new PR, [VladNaimark](https://github.com/VladNaimark) lay the ground work and should deserve the credit for the work.

You can read more about the pattern here in [urql documentation](https://formidable.com/open-source/urql/docs/api/core/#combinederror) which served as inspiration for the new functionality.