### PR TITLE
Correctly Escape Double-Quotes in Deprecation Message

### DIFF
--- a/Sources/SwiftGraphQLCodegen/Generator/Field.swift
+++ b/Sources/SwiftGraphQLCodegen/Generator/Field.swift
@@ -89,7 +89,9 @@ extension Field {
 
     private var availability: String {
         if isDeprecated {
-            let message = deprecationReason ?? ""
+            // NOTE: It's possible that a string contains double-quoted characters in deprecation reason.
+            //       http://spec.graphql.org/October2021/#sec-Language.Directives
+            let message = deprecationReason?.replacingOccurrences(of: "\"", with: "\\\"") ?? ""
             return "@available(*, deprecated, message: \"\(message)\")"
         }
         return ""

--- a/Tests/SwiftGraphQLCodegenTests/Generator/FieldTests.swift
+++ b/Tests/SwiftGraphQLCodegenTests/Generator/FieldTests.swift
@@ -40,6 +40,43 @@ final class FieldTests: XCTestCase {
            }
            """)
     }
+    
+    func testDeprecatedFieldWithEscapeCharacters() throws {
+        let field = Field(
+            name: "id",
+            description: "Object identifier.\nMultiline.",
+            args: [],
+            type: .named(.scalar("ID")),
+            isDeprecated: true,
+            deprecationReason: "Use \"ID\" instead."
+        )
+
+        let generated = try field.getDynamicSelection(
+            parent: "TestType",
+            context: Context.from(scalars: ["ID": "String"])
+        ).format()
+
+        generated.assertInlineSnapshot(matching: """
+           /// Object identifier.
+           /// Multiline.
+           @available(*, deprecated, message: "Use \\\"ID\\\" instead.")
+           public func id() throws -> String? {
+             let field = GraphQLField.leaf(
+               field: "id",
+               parent: "TestType",
+               arguments: []
+             )
+             self.__select(field)
+           
+             switch self.__state {
+             case .decoding:
+               return try self.__decode(field: field.alias!) { try String?(from: $0) }
+             case .selecting:
+               return nil
+             }
+           }
+           """)
+    }
 
     // MARK: - Scalar
 


### PR DESCRIPTION
This PR fixes a bug where double-quotes in `@deprecated` directive description would break the generated code.

Huge thanks to [thingdeux](https://github.com/thingdeux) for tracking this down. I am truly amazed 😄 