### PR TITLE
Fix GitHub Publish Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - 'Sources/**/*'
+      - 'Tests/**/*'
+      - 'Package.swift'
+      - '.github/workflows/publish.yml'
 
 jobs:
   build:


### PR DESCRIPTION
This PR fixes a bug where the publish action would only get triggered whenever the Sources changed. Because of this, the latest PR #137 wasn't published.