### PR TITLE
fix: Expose WebSocket close method

### DIFF
--- a/Sources/GraphQLWebSocket/Client.swift
+++ b/Sources/GraphQLWebSocket/Client.swift
@@ -488,6 +488,11 @@ public class GraphQLWebSocket: WebSocketDelegate {
         self.emitter.share().eraseToAnyPublisher()
     }
     
+    /// Correctly closes the connection with the server.
+    public func close(code: CloseCode = .normalClosure) {
+        close(code: code.rawValue)
+    }
+    
     /// Creates a publisher that emits results received from the server
     /// of the provided query.
     ///


### PR DESCRIPTION
Call it before app resigns active, so OS won't abort the connection like this: Receive failed with error "Software caused connection abort"