### PR TITLE
fix: Fix ExecutionResult Decoder to Conform to GraphQL Spec

### DIFF
--- a/Sources/SwiftGraphQL/Selection/Selection+Transform.swift
+++ b/Sources/SwiftGraphQL/Selection/Selection+Transform.swift
@@ -55,7 +55,7 @@ public extension Selection {
             switch fields.__state {
             case let .decoding(data):
                 switch data.value {
-                case is Void:
+                case is Void, is NSNull:
                     throw ObjectDecodingError.unexpectedNilValue
                 default:
                     return try self.__decode(data: data)

--- a/Tests/GraphQLTests/ExecutionTests.swift
+++ b/Tests/GraphQLTests/ExecutionTests.swift
@@ -1,0 +1,145 @@
+import GraphQL
+import XCTest
+
+/// A suite of tests that check all edge cases of the response format as described in [GraphQL Spec Response Format](http://spec.graphql.org/October2021/#sec-Response-Format) section.
+final class ExecutionTests: XCTestCase {
+    
+    func testExecutionWithDataAndErrors() throws {
+        let result: ExecutionResult = """
+            {
+              "data": "Hello World!",
+              "errors": [
+                {
+                  "message": "Message.",
+                  "locations": [ { "line": 6, "column": 7 } ],
+                  "path": [ "hero", "heroFriends", 1, "name" ]
+                }
+              ]
+            }
+            """.decode()
+        
+        XCTAssertEqual(
+            result,
+            ExecutionResult(
+                data: AnyCodable("Hello World!"),
+                errors: [
+                    GraphQL.GraphQLError(
+                        message: "Message.",
+                        locations: [
+                            GraphQL.GraphQLError.Location(line: 6, column: 7)
+                        ],
+                        path: [
+                            GraphQL.GraphQLError.PathLink.path("hero"),
+                            GraphQL.GraphQLError.PathLink.path("heroFriends"),
+                            GraphQL.GraphQLError.PathLink.index(1),
+                            GraphQL.GraphQLError.PathLink.path("name")
+                        ],
+                        extensions: nil
+                    )
+                ],
+                hasNext: nil,
+                extensions: nil
+            )
+        )
+    }
+    
+    func testExecutionWithErrorsField() throws {
+        let result: ExecutionResult = """
+            {
+              "errors": [
+                {
+                  "message": "Message.",
+                  "locations": [ { "line": 6, "column": 7 } ],
+                  "path": [ "hero", "heroFriends", 1, "name" ]
+                }
+              ]
+            }
+            """.decode()
+        
+        XCTAssertEqual(
+            result,
+            GraphQL.ExecutionResult(
+                data: nil,
+                errors: [
+                    GraphQL.GraphQLError(
+                        message: "Message.",
+                        locations: [
+                            GraphQL.GraphQLError.Location(line: 6, column: 7)
+                        ],
+                        path: [
+                            GraphQL.GraphQLError.PathLink.path("hero"),
+                            GraphQL.GraphQLError.PathLink.path("heroFriends"),
+                            GraphQL.GraphQLError.PathLink.index(1),
+                            GraphQL.GraphQLError.PathLink.path("name")
+                        ],
+                        extensions: nil
+                    )
+                ],
+                hasNext: nil,
+                extensions: nil
+            )
+        )
+    }
+    
+    func testExecutionWithoutErrorsField() throws {
+        let result: ExecutionResult = """
+            {
+              "data": "Hello World!"
+            }
+            """.decode()
+        
+        XCTAssertEqual(
+            result,
+            GraphQL.ExecutionResult(
+                data: AnyCodable("Hello World!"),
+                errors: nil,
+                hasNext: nil,
+                extensions: nil
+            )
+        )
+    }
+    
+    func testExecutionWithErrorsWithExtensions() throws {
+        let result: ExecutionResult = """
+            {
+              "errors": [
+                {
+                  "message": "Bad Request Exception",
+                  "extensions": {
+                    "code": "BAD_USER_INPUT",
+                  }
+                }
+              ],
+              "data": null
+            }
+            """.decode()
+        
+        XCTAssertEqual(
+            result,
+            GraphQL.ExecutionResult(
+                data: nil,
+                errors: [
+                    GraphQL.GraphQLError(
+                        message: "Bad Request Exception",
+                        locations: nil,
+                        path: nil,
+                        extensions: [
+                            "code": AnyCodable("BAD_USER_INPUT")
+                        ]
+                    )
+                ],
+                hasNext: nil,
+                extensions: nil
+            )
+        )
+    }
+}
+
+
+extension String {
+    /// Converts a string representation of a GraphQL result into the execution result if possible.
+    fileprivate func decode() -> ExecutionResult {
+        let decoder = JSONDecoder()
+        return try! decoder.decode(ExecutionResult.self, from: self.data(using: .utf8)!)
+    }
+}

--- a/Tests/SwiftGraphQLTests/Selection/SelectionDecodingTests.swift
+++ b/Tests/SwiftGraphQLTests/Selection/SelectionDecodingTests.swift
@@ -213,11 +213,37 @@ final class SelectionDecodingTests: XCTestCase {
 
         XCTAssertThrowsError(try selection.nonNullOrFail.decode(raw: result.data)) { (error) -> Void in
             switch error {
-            case let ScalarDecodingError.unexpectedScalarType(expected: expected, received: _):
-                XCTAssertEqual(expected, "String")
+            case ObjectDecodingError.unexpectedNilValue:
+                ()
             default:
                 XCTFail()
             } 
+        }
+    }
+    
+    func testInvalidScalarError() throws {
+        let result: ExecutionResult = """
+            {
+              "data": 1
+            }
+            """.execution()
+        
+        let selection = Selection<String, String> {
+            switch $0.__state {
+            case let .decoding(data):
+                return try String(from: data)
+            case .selecting:
+                return "wrong"
+            }
+        }
+
+        XCTAssertThrowsError(try selection.nonNullOrFail.decode(raw: result.data)) { (error) -> Void in
+            switch error {
+            case let ScalarDecodingError.unexpectedScalarType(expected: expected, received: _): 
+                XCTAssertEqual(expected, "String")
+            default:
+                XCTFail()
+            }
         }
     }
 

--- a/Tests/SwiftGraphQLTests/Selection/SelectionDecodingTests.swift
+++ b/Tests/SwiftGraphQLTests/Selection/SelectionDecodingTests.swift
@@ -46,6 +46,25 @@ final class SelectionDecodingTests: XCTestCase {
         XCTAssertEqual(decoded, nil)
         XCTAssertEqual(result.errors, nil)
     }
+    
+    func testMissingDataField() throws {
+        let result: ExecutionResult = """
+            {}
+            """.execution()
+
+        let selection = Selection<String?, String?> {
+            switch $0.__state {
+            case let .decoding(data):
+                return try String?(from: data)
+            case .selecting:
+                return "wrong"
+            }
+        }
+        
+        let decoded = try selection.decode(raw: result.data)
+        XCTAssertEqual(decoded, nil)
+        XCTAssertEqual(result.errors, nil)
+    }
 
     func testNullableNSNull() throws {
         let result: ExecutionResult = """


### PR DESCRIPTION
This PR handles an edge case where the decoder would crash if there was no `data` field in the execution result. GraphQL Specification allows the possibility of missing `data` field if the execution error occurred during parsing of the result.

Instead of having two different `nil` states in the `ExecutionResult` (i.e. Swift's `nil` and `AnyCodable(nil)`), I decided to extend the decoder so that it correctly auto assigns a `nil` value to `data` if it's not present.