### PR TITLE
Removes dependency on Starscream

### DIFF
--- a/Formula/SwiftGraphQL.rb
+++ b/Formula/SwiftGraphQL.rb
@@ -3,8 +3,8 @@ class Swiftgraphql < Formula
   homepage "https://swift-graphql.org"
   license "MIT"
   
-  url "https://github.com/maticzav/swift-graphql/archive/5.0.8.tar.gz"
-  sha256 "cd8fd80bd962b586a695fa72b4f91931c0e0566e262d33721ac34880432c544c"
+  url "https://github.com/maticzav/swift-graphql/archive/5.0.10.tar.gz"
+  sha256 "045d9261ad19bd1c134f4e2f414fdd740b4ffb1bc98cea942fdd119da23f68b0"
   
   head "https://github.com/maticzav/swift-graphql.git"
 

--- a/Package.swift
+++ b/Package.swift
@@ -6,9 +6,9 @@ let package = Package(
     name: "swift-graphql",
     platforms: [
         .iOS(.v15),
-        .macOS(.v10_15),
-        .tvOS(.v13),
-        .watchOS(.v6)
+        .macOS(.v12),
+        .tvOS(.v15),
+        .watchOS(.v8)
     ],
     products: [
         // SwiftGraphQL
@@ -27,7 +27,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-format", "508.0.0"..<"510.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0"),
         .package(url: "https://github.com/dominicegginton/Spinner", from: "2.0.0"),
         .package(url: "https://github.com/JohnSundell/Files", from: "4.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
@@ -41,7 +40,6 @@ let package = Package(
             dependencies: [
                 "GraphQL",
                 .product(name: "Logging", package: "swift-log"),
-                "Starscream"
             ],
             path: "Sources/GraphQLWebSocket",
             exclude: ["README.md"]

--- a/Sources/GraphQLWebSocket/Client.swift
+++ b/Sources/GraphQLWebSocket/Client.swift
@@ -314,7 +314,7 @@ public class GraphQLWebSocket: WebSocketDelegate {
         switch (self.health, message) {
         case (.acknowledged, _), (.disposed, _), (_, .initialise):
             // We can send any message when the connection has been ACK and meta messages when the server hasn't ACK the connection yet.
-            socket.write(data: data) { _ in }
+            socket.send(data) { _ in }
             self.config.logger.debug("\(message.description) sent to the server!")
             
         default:

--- a/Sources/GraphQLWebSocket/Client.swift
+++ b/Sources/GraphQLWebSocket/Client.swift
@@ -3,7 +3,6 @@
 import Combine
 import GraphQL
 import Foundation
-import Starscream
 
 /// A GraphQL client that lets you send queries over WebSocket protocol.
 ///

--- a/Sources/GraphQLWebSocket/Client.swift
+++ b/Sources/GraphQLWebSocket/Client.swift
@@ -78,13 +78,11 @@ public class GraphQLWebSocket: WebSocketDelegate {
         /// Open WebSocket connection has been acknowledged
         case acknowledged(payload: [String: AnyCodable]?)
         
-        /// Ping has been received or sent.
-        ///
-        /// - parameter received: Tells whether the ping was received from the server. If `false` the client sent the ping.
-        case ping(received: Bool, payload: [String: AnyCodable]?)
+        /// Ping has been sent.
+        case pingSent
         
         /// Pong has been received.
-        case pong
+        case pongReceived
         
         /// A message from the server has been received.
         case message(ServerMessage)
@@ -195,7 +193,7 @@ public class GraphQLWebSocket: WebSocketDelegate {
 
         case .pong:
             self.config.logger.debug("Received pong from the server...")
-            self.emitter.send(.pong)
+            self.emitter.send(.pongReceived)
             self.connectionDroppedTimer?.invalidate()
             break
             
@@ -344,7 +342,7 @@ public class GraphQLWebSocket: WebSocketDelegate {
     /// Sends a ping request and starts the response timeout.
     private func ping() {
         self.socket?.sendPing(pongReceiveHandler: { _ in }) // NOTE: sent also via delegate
-        self.emitter.send(Event.ping(received: false, payload: nil))
+        self.emitter.send(Event.pingSent)
         self.config.logger.debug("Emitted a PING message!")
         
         // We schedule a response timeout that has to be cleared

--- a/Sources/GraphQLWebSocket/Extensions/WebSocket+Extensions.swift
+++ b/Sources/GraphQLWebSocket/Extensions/WebSocket+Extensions.swift
@@ -5,6 +5,6 @@ extension WebSocketClient {
     
     /// Disconnects from a socket using one of the close codes in the GraphQL WS specification.
     func disconnect(closeCode: CloseCode) {
-        self.disconnect(closeCode: closeCode.rawValue)
+        self.disconnect(closeCode: Int(closeCode.rawValue))
     }
 }

--- a/Sources/GraphQLWebSocket/Extensions/WebSocket+Extensions.swift
+++ b/Sources/GraphQLWebSocket/Extensions/WebSocket+Extensions.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Starscream
 
 extension WebSocketClient {
     

--- a/Sources/GraphQLWebSocket/WebSocketClient.swift
+++ b/Sources/GraphQLWebSocket/WebSocketClient.swift
@@ -93,7 +93,6 @@ class WebSocket: NSObject, WebSocketClient, URLSessionWebSocketDelegate {
     }
 
     func disconnect(closeCode: Int) {
-        assert(socket.state == .running)
         // NOTE: URLSessionWebSocketTask.CloseCode limits allowed close codes
         let closeCode = URLSessionWebSocketTask.CloseCode(rawValue: Int(closeCode)) ?? .normalClosure
         socket.cancel(with: closeCode, reason: nil)

--- a/Sources/GraphQLWebSocket/WebSocketClient.swift
+++ b/Sources/GraphQLWebSocket/WebSocketClient.swift
@@ -14,8 +14,8 @@ import Foundation
 public protocol WebSocketClient: AnyObject {
     func connect()
     func disconnect(closeCode: Int)
-    func write(string: String, completion: ((Error?) -> ())?)
-    func write(data: Data, completion: ((Error?) -> ())?)
+    func send(_ string: String, completion: ((Error?) -> ())?)
+    func send(_ data: Data, completion: ((Error?) -> ())?)
     /// Note that the callback is called after PING is sent and PONG received.
     func sendPing(pongReceiveHandler: ((Error?) -> ())?)
 }
@@ -62,6 +62,7 @@ class WebSocket: NSObject, WebSocketClient, URLSessionWebSocketDelegate {
 
     /// Starts receiving incoming messages.
     private func receive() {
+        assert(delegate != nil, "Delegate not set")
         socket.receive { [weak self] result in
             guard let self else { return }
             self.callbackQueue.async {
@@ -98,14 +99,14 @@ class WebSocket: NSObject, WebSocketClient, URLSessionWebSocketDelegate {
         socket.cancel(with: closeCode, reason: nil)
     }
 
-    func write(string: String, completion: ((Error?) -> ())?) {
+    func send(_ string: String, completion: ((Error?) -> ())?) {
         assert(socket.state == .running)
         socket.send(.string(string)) { error in
             completion?(error)
         }
     }
 
-    func write(data: Data, completion: ((Error?) -> ())?) {
+    func send(_ data: Data, completion: ((Error?) -> ())?) {
         assert(socket.state == .running)
         socket.send(.data(data)) { error in
             completion?(error)

--- a/Sources/GraphQLWebSocket/WebSocketClient.swift
+++ b/Sources/GraphQLWebSocket/WebSocketClient.swift
@@ -163,13 +163,8 @@ class WebSocket: NSObject, WebSocketClient, URLSessionWebSocketDelegate {
     }
     
     func write(pong: Data, completion: (() -> ())?) {
-        assert(socket.state == .running)
-        // TODO: test, check if URLSessionWebSocketTask responds to ping
-        struct Pong: Encodable {
-            var type = "pong"
-        }
-        let data = try! JSONEncoder().encode(Pong())
-        write(data: data, completion: completion)
+        // NOTE: URLSessionWebSocketTask reponds to PINGs sent by server
+        completion?()
     }
     
     // MARK: URLSessionWebSocketDelegate

--- a/Sources/GraphQLWebSocket/WebSocketClient.swift
+++ b/Sources/GraphQLWebSocket/WebSocketClient.swift
@@ -1,0 +1,200 @@
+//
+//  WebSocketClient.swift
+//
+//
+//  Created by Michał A on 2023/10/25.
+//
+
+// MARK: - Starscream types
+
+// see also https://github.com/daltoniam/Starscream/blob/master/Sources/Starscream/WebSocket.swift
+
+import Foundation
+
+public protocol WebSocketClient: AnyObject {
+    func connect()
+    func disconnect(closeCode: UInt16)
+    func write(string: String, completion: (() -> ())?)
+    func write(stringData: Data, completion: (() -> ())?)
+    func write(data: Data, completion: (() -> ())?)
+    func write(ping: Data, completion: (() -> ())?)
+    func write(pong: Data, completion: (() -> ())?)
+}
+
+extension WebSocketClient {
+    func write(string: String) {
+        write(string: string, completion: nil)
+    }
+    
+    func write(data: Data) {
+        write(data: data, completion: nil)
+    }
+    
+    func write(ping: Data) {
+        write(ping: ping, completion: nil)
+    }
+    
+    func write(pong: Data) {
+        write(pong: pong, completion: nil)
+    }
+    
+    func disconnect() {
+        disconnect(closeCode: UInt16(URLSessionWebSocketTask.CloseCode.normalClosure.rawValue))
+    }
+    
+    func write(stringData: Data, completion: (() -> ())?) {
+        let string = String(data: stringData, encoding: .utf8)!
+        write(string: string, completion: completion)
+    }
+    
+    func write(stringData: Data) {
+        write(stringData: stringData, completion: nil)
+    }
+}
+
+public enum WebSocketEvent {
+    case connected([String: String])
+    case disconnected(String, UInt16)
+    case text(String)
+    case binary(Data)
+    case pong(Data?)
+    case ping(Data?) // NOTE: not used
+    case error(Error?)
+    case viabilityChanged(Bool) // NOTE: not used
+    case reconnectSuggested(Bool) // NOTE: not used
+    case cancelled // NOTE: not used
+    case peerClosed // NOTE: not used
+}
+
+protocol WebSocketDelegate: AnyObject {
+    func didReceive(event: WebSocketEvent, client: WebSocketClient)
+}
+
+private enum HTTPWSHeader {
+    static let protocolName = "Sec-WebSocket-Protocol"
+}
+
+// MARK: - URLSession replacement of Starscream WebSocket
+
+// see also https://github.com/daltoniam/Starscream/blob/master/Sources/Engine/NativeEngine.swift
+
+class WebSocket: NSObject, WebSocketClient, URLSessionWebSocketDelegate {
+    weak var delegate: WebSocketDelegate?
+    
+    private let callbackQueue: DispatchQueue
+    
+    private let socket: URLSessionWebSocketTask
+    
+    init(request: URLRequest, session: URLSession = .shared, callbackQueue: DispatchQueue = DispatchQueue.main) {
+        assert(request.allHTTPHeaderFields?[HTTPWSHeader.protocolName] != nil)
+        socket = session.webSocketTask(with: request)
+        self.callbackQueue = callbackQueue
+    }
+
+    /// Starts receiving incoming messages.
+    private func receive() {
+        socket.receive { [weak self] result in
+            guard let self else { return }
+            self.callbackQueue.async {
+                switch result {
+                case let .success(message):
+                    switch message {
+                    case let .data(data):
+                        self.delegate?.didReceive(event: .binary(data), client: self)
+                    case let .string(string):
+                        self.delegate?.didReceive(event: .text(string), client: self)
+                    @unknown default:
+                        assertionFailure("Unknown message type")
+                    }
+                case let .failure(error):
+                    self.delegate?.didReceive(event: .error(error), client: self)
+                }
+            }
+            self.receive()
+        }
+    }
+    
+    // MARK: WebSocketClient
+    
+    func connect() {
+        assert(socket.state == .suspended)
+        socket.delegate = self
+        receive()
+        socket.resume()
+    }
+    
+    func disconnect(closeCode: UInt16) {
+        assert(socket.state == .running)
+        // NOTE: URLSessionWebSocketTask.CloseCode limits allowed close codes
+        let closeCode = URLSessionWebSocketTask.CloseCode(rawValue: Int(closeCode)) ?? .normalClosure
+        socket.cancel(with: closeCode, reason: nil)
+    }
+    
+    func write(string: String, completion: (() -> ())?) {
+        assert(socket.state == .running)
+        socket.send(.string(string)) { error in
+            // NOTE: Starscream NativeEngine ignores the error
+            assert(error == nil)
+            completion?()
+        }
+    }
+
+    func write(data: Data, completion: (() -> ())?) {
+        assert(socket.state == .running)
+        socket.send(.data(data)) { error in
+            // NOTE: Starscream NativeEngine ignores the error
+            assert(error == nil)
+            completion?()
+        }
+    }
+    
+    func write(ping: Data, completion: (() -> ())?) {
+        assert(socket.state == .running)
+        socket.sendPing(pongReceiveHandler: { error in
+            // NOTE: Starscream NativeEngine ignores the error
+            assert(error == nil)
+            completion?()
+            guard error == nil else { return }
+            self.callbackQueue.async { [weak self] in
+                guard let self else { return }
+                self.delegate?.didReceive(event: .pong(nil), client: self)
+            }
+        })
+    }
+    
+    func write(pong: Data, completion: (() -> ())?) {
+        assert(socket.state == .running)
+        // TODO: test, check if URLSessionWebSocketTask responds to ping
+        struct Pong: Encodable {
+            var type = "pong"
+        }
+        let data = try! JSONEncoder().encode(Pong())
+        write(data: data, completion: completion)
+    }
+    
+    // MARK: URLSessionWebSocketDelegate
+    
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        callbackQueue.async { [weak self] in
+            guard let self else { return }
+            let protocolName = `protocol` ?? ""
+            self.delegate?.didReceive(event: .connected([HTTPWSHeader.protocolName: protocolName]), client: self)
+        }
+    }
+    
+    func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        callbackQueue.async { [weak self] in
+            guard let self else { return }
+            let message = reason.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+            let closeCode = UInt16(closeCode.rawValue)
+            self.delegate?.didReceive(event: .disconnected(message, closeCode), client: self)
+        }
+    }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        callbackQueue.async { [weak self] in
+            guard let self else { return }
+            self.delegate?.didReceive(event: .error(error), client: self)
+        }
+    }
+}

--- a/Sources/GraphQLWebSocket/WebSocketClient.swift
+++ b/Sources/GraphQLWebSocket/WebSocketClient.swift
@@ -13,57 +13,26 @@ import Foundation
 
 public protocol WebSocketClient: AnyObject {
     func connect()
-    func disconnect(closeCode: UInt16)
-    func write(string: String, completion: (() -> ())?)
-    func write(stringData: Data, completion: (() -> ())?)
-    func write(data: Data, completion: (() -> ())?)
-    func write(ping: Data, completion: (() -> ())?)
-    func write(pong: Data, completion: (() -> ())?)
+    func disconnect(closeCode: Int)
+    func write(string: String, completion: ((Error?) -> ())?)
+    func write(data: Data, completion: ((Error?) -> ())?)
+    /// Note that the callback is called after PING is sent and PONG received.
+    func sendPing(pongReceiveHandler: ((Error?) -> ())?)
 }
 
 extension WebSocketClient {
-    func write(string: String) {
-        write(string: string, completion: nil)
-    }
-    
-    func write(data: Data) {
-        write(data: data, completion: nil)
-    }
-    
-    func write(ping: Data) {
-        write(ping: ping, completion: nil)
-    }
-    
-    func write(pong: Data) {
-        write(pong: pong, completion: nil)
-    }
-    
     func disconnect() {
-        disconnect(closeCode: UInt16(URLSessionWebSocketTask.CloseCode.normalClosure.rawValue))
-    }
-    
-    func write(stringData: Data, completion: (() -> ())?) {
-        let string = String(data: stringData, encoding: .utf8)!
-        write(string: string, completion: completion)
-    }
-    
-    func write(stringData: Data) {
-        write(stringData: stringData, completion: nil)
+        disconnect(closeCode: URLSessionWebSocketTask.CloseCode.normalClosure.rawValue)
     }
 }
 
 public enum WebSocketEvent {
-    case connected([String: String])
-    case disconnected(String, UInt16)
+    case connected(protocolName: String?)
+    case disconnected(message: String?, closeCode: Int)
     case text(String)
     case binary(Data)
-    case pong(Data?)
-    case ping(Data?) // NOTE: not used
+    case pong
     case error(Error?)
-    case viabilityChanged(Bool) // NOTE: not used
-    case reconnectSuggested(Bool) // NOTE: not used
-    case cancelled // NOTE: not used
-    case peerClosed // NOTE: not used
 }
 
 protocol WebSocketDelegate: AnyObject {
@@ -80,11 +49,11 @@ private enum HTTPWSHeader {
 
 class WebSocket: NSObject, WebSocketClient, URLSessionWebSocketDelegate {
     weak var delegate: WebSocketDelegate?
-    
+
     private let callbackQueue: DispatchQueue
-    
+
     private let socket: URLSessionWebSocketTask
-    
+
     init(request: URLRequest, session: URLSession = .shared, callbackQueue: DispatchQueue = DispatchQueue.main) {
         assert(request.allHTTPHeaderFields?[HTTPWSHeader.protocolName] != nil)
         socket = session.webSocketTask(with: request)
@@ -113,79 +82,68 @@ class WebSocket: NSObject, WebSocketClient, URLSessionWebSocketDelegate {
             self.receive()
         }
     }
-    
+
     // MARK: WebSocketClient
-    
+
     func connect() {
         assert(socket.state == .suspended)
         socket.delegate = self
         receive()
         socket.resume()
     }
-    
-    func disconnect(closeCode: UInt16) {
+
+    func disconnect(closeCode: Int) {
         assert(socket.state == .running)
         // NOTE: URLSessionWebSocketTask.CloseCode limits allowed close codes
         let closeCode = URLSessionWebSocketTask.CloseCode(rawValue: Int(closeCode)) ?? .normalClosure
         socket.cancel(with: closeCode, reason: nil)
     }
-    
-    func write(string: String, completion: (() -> ())?) {
+
+    func write(string: String, completion: ((Error?) -> ())?) {
         assert(socket.state == .running)
         socket.send(.string(string)) { error in
-            // NOTE: Starscream NativeEngine ignores the error
-            assert(error == nil)
-            completion?()
+            completion?(error)
         }
     }
 
-    func write(data: Data, completion: (() -> ())?) {
+    func write(data: Data, completion: ((Error?) -> ())?) {
         assert(socket.state == .running)
         socket.send(.data(data)) { error in
-            // NOTE: Starscream NativeEngine ignores the error
-            assert(error == nil)
-            completion?()
+            completion?(error)
         }
     }
-    
-    func write(ping: Data, completion: (() -> ())?) {
+
+    func sendPing(pongReceiveHandler completion: ((Error?) -> ())?) {
         assert(socket.state == .running)
         socket.sendPing(pongReceiveHandler: { error in
-            // NOTE: Starscream NativeEngine ignores the error
-            assert(error == nil)
-            completion?()
+            completion?(error)
             guard error == nil else { return }
             self.callbackQueue.async { [weak self] in
                 guard let self else { return }
-                self.delegate?.didReceive(event: .pong(nil), client: self)
+                self.delegate?.didReceive(event: .pong, client: self)
             }
         })
     }
-    
-    func write(pong: Data, completion: (() -> ())?) {
-        // NOTE: URLSessionWebSocketTask reponds to PINGs sent by server
-        completion?()
-    }
-    
+
     // MARK: URLSessionWebSocketDelegate
-    
+
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
         callbackQueue.async { [weak self] in
             guard let self else { return }
             let protocolName = `protocol` ?? ""
-            self.delegate?.didReceive(event: .connected([HTTPWSHeader.protocolName: protocolName]), client: self)
+            self.delegate?.didReceive(event: .connected(protocolName: protocolName), client: self)
         }
     }
-    
+
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
         callbackQueue.async { [weak self] in
             guard let self else { return }
-            let message = reason.flatMap { String(data: $0, encoding: .utf8) } ?? ""
-            let closeCode = UInt16(closeCode.rawValue)
-            self.delegate?.didReceive(event: .disconnected(message, closeCode), client: self)
+            let message = reason.flatMap { String(data: $0, encoding: .utf8) }
+            let closeCode = closeCode.rawValue
+            self.delegate?.didReceive(event: .disconnected(message: message, closeCode: closeCode), client: self)
         }
     }
-    
+
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         callbackQueue.async { [weak self] in
             guard let self else { return }

--- a/SwiftGraphQL.podspec
+++ b/SwiftGraphQL.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |spec|
   spec.summary      = 'GraphQL query generator and client for Swift'
   spec.license      = { :type => 'MIT' }
 
-  spec.version      = '5.0.8'
+  spec.version      = '5.0.10'
   spec.source       = { 
 		:git => 'https://github.com/maticzav/swift-graphql.git', 
 		:tag => spec.version.to_s 


### PR DESCRIPTION
I decided that for now it will be best to keep `GraphQLWebSocket` (with the GraphQL subscription logic) intact and provide a drop in replacement for the [Starscream `WebSocket` class](https://github.com/daltoniam/Starscream/blob/master/Sources/Starscream/WebSocket.swift).

This has a few limitations - for example `WebSocketClient` protocol does not forward errors when sending data but as of now `GraphQLWebSocket` does not handle it anyway.

Please search for **TODO** and **NOTE** comments in the code.

BTW I noticed that [`Starscream`](https://github.com/daltoniam/Starscream/) does allow to use `URLSession` WebSocket, as its "engine" see https://github.com/daltoniam/Starscream/blob/master/Sources/Engine/NativeEngine.swift