### PR TITLE
Concurrency Stage 1: Introduces initial wrapper-style async/await support

### DIFF
--- a/Sources/SwiftGraphQLClient/Client/Core.swift
+++ b/Sources/SwiftGraphQLClient/Client/Core.swift
@@ -262,6 +262,12 @@ public class Client: GraphQLClient, ObservableObject {
     /// APIs, async/await inherently does __not__ support multiple
     /// return values. If you expect multiple values from an async/await
     /// API, please use the corresponding publisher API instead.
+    ///
+    /// Additionally, due to the differences between async/await and
+    /// Combine publishers, the async APIs will only return a single value,
+    /// even if the query is invalidated. Therefore if you currently 
+    /// rely on invalidation behaviour provided by publishers we suggest
+    /// you continue to use the Combine APIs.
     public func query(
         _ args: ExecutionArgs,
         request: URLRequest? = nil,

--- a/Sources/SwiftGraphQLClient/Client/Core.swift
+++ b/Sources/SwiftGraphQLClient/Client/Core.swift
@@ -255,7 +255,21 @@ public class Client: GraphQLClient, ObservableObject {
         
         return self.execute(operation: operation)
     }
-    
+
+    /// Executes a query request with given execution parameters.
+    ///
+    /// Note: While this behaves much the same as the published-based
+    /// APIs, async/await inherently does __not__ support multiple
+    /// return values. If you expect multiple values from an async/await
+    /// API, please use the corresponding publisher API instead.
+    public func query(
+        _ args: ExecutionArgs,
+        request: URLRequest? = nil,
+        policy: Operation.Policy = .cacheFirst
+    ) async -> OperationResult {
+        await self.query(args, request: request, policy: policy).first()
+    }
+
     /// Executes a mutation request with given execution parameters.
     public func mutate(
         _ args: ExecutionArgs,
@@ -273,7 +287,21 @@ public class Client: GraphQLClient, ObservableObject {
         
         return self.execute(operation: operation)
     }
-    
+
+    /// Executes a mutation request with given execution parameters.
+    ///
+    /// Note: While this behaves much the same as the published-based
+    /// APIs, async/await inherently does __not__ support multiple
+    /// return values. If you expect multiple values from an async/await
+    /// API, please use the corresponding publisher API instead.
+    public func mutate(
+        _ args: ExecutionArgs,
+        request: URLRequest? = nil,
+        policy: Operation.Policy = .cacheFirst
+    ) async -> OperationResult {
+        await self.mutate(args, request: request, policy: policy).first()
+    }
+
     /// Executes a subscription request with given execution parameters.
     public func subscribe(
         _ args: ExecutionArgs,

--- a/Sources/SwiftGraphQLClient/Client/Selection.swift
+++ b/Sources/SwiftGraphQLClient/Client/Selection.swift
@@ -77,8 +77,7 @@ extension GraphQLClient {
     }
     
     // MARK: - Decoders
-    
-    
+
     /// Executes a query and returns a stream of decoded values.
     public func query<T, TypeLock>(
         _ selection: Selection<T, TypeLock>,
@@ -97,7 +96,17 @@ extension GraphQLClient {
             }
             .eraseToAnyPublisher()
     }
-    
+
+    /// Executes a query request with given execution parameters.
+    public func query<T, TypeLock>(
+        _ selection: Selection<T, TypeLock>,
+        as operationName: String? = nil,
+        request: URLRequest? = nil,
+        policy: Operation.Policy = .cacheFirst
+    ) async throws -> DecodedOperationResult<T> where TypeLock: GraphQLHttpOperation {
+        try await self.query(selection, as: operationName, request: request, policy: policy).first()
+    }
+
     /// Executes a mutation and returns a stream of decoded values.
     public func mutate<T, TypeLock>(
         _ selection: Selection<T, TypeLock>,
@@ -116,7 +125,16 @@ extension GraphQLClient {
             }
             .eraseToAnyPublisher()
     }
-    
+
+    public func mutate<T, TypeLock>(
+        _ selection: Selection<T, TypeLock>,
+        as operationName: String? = nil,
+        request: URLRequest? = nil,
+        policy: Operation.Policy = .cacheFirst
+    ) async throws -> DecodedOperationResult<T> where TypeLock: GraphQLHttpOperation {
+        try await self.mutate(selection, as: operationName, request: request, policy: policy).first()
+    }
+
     /// Creates a subscription stream of decoded values from the given query.
     public func subscribe<T, TypeLock>(
         to selection: Selection<T, TypeLock>,

--- a/Tests/SwiftGraphQLClientTests/AsyncClientTests.swift.swift
+++ b/Tests/SwiftGraphQLClientTests/AsyncClientTests.swift.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Shaps Benkau on 27/10/2023.
+//
+
+import Foundation

--- a/Tests/SwiftGraphQLClientTests/AsyncClientTests.swift.swift
+++ b/Tests/SwiftGraphQLClientTests/AsyncClientTests.swift.swift
@@ -1,8 +1,125 @@
-//
-//  File.swift
-//  
-//
-//  Created by Shaps Benkau on 27/10/2023.
-//
+import GraphQL
+import SwiftGraphQLClient
+import XCTest
+import Combine
+import SwiftGraphQL
 
-import Foundation
+final class AsyncInterfaceTests: XCTestCase {
+    func testAsyncSelectionQueryReturnsValue() async throws {
+        let selection = Selection<String, Objects.User> {
+            try $0.id()
+        }
+
+        let client = MockClient(customExecute: { operation in
+            let id = GraphQLField.leaf(field: "id", parent: "User", arguments: [])
+
+            let user = GraphQLField.composite(
+                field: "user",
+                parent: "Query",
+                type: "User",
+                arguments: [],
+                selection: selection.__selection()
+            )
+
+            let result = OperationResult(
+                operation: operation,
+                data: [
+                    user.alias!: [
+                        id.alias!: "123"
+                    ]
+                ],
+                error: nil
+            )
+            return Just(result).eraseToAnyPublisher()
+        })
+
+
+        let result = try await client.query(Objects.Query.user(selection: selection))
+        XCTAssertEqual(result.data, "123")
+    }
+
+    func testAsyncSelectionQueryThrowsError() async throws {
+        let selection = Selection<String, Objects.User> {
+            try $0.id()
+        }
+
+        let client = MockClient(customExecute: { operation in
+            let result = OperationResult(
+                operation: operation,
+                data: ["unknown_field": "123"],
+                error: nil
+            )
+            return Just(result).eraseToAnyPublisher()
+        })
+
+        await XCTAssertThrowsError(of: ObjectDecodingError.self) {
+            try await client.query(Objects.Query.user(selection: selection))
+        }
+    }
+
+    func testAsyncSelectionMutationReturnsValue() async throws {
+        let selection = Selection.AuthPayload<String?> {
+            try $0.on(
+                authPayloadSuccess: Selection.AuthPayloadSuccess<String?> {
+                    try $0.token()
+                },
+                authPayloadFailure: Selection.AuthPayloadFailure<String?> { _ in
+                    nil
+                }
+            )
+        }
+
+        let client = MockClient(customExecute: { operation in
+            let token = GraphQLField.leaf(field: "token", parent: "AuthPayloadSuccess", arguments: [])
+
+            let auth = GraphQLField.composite(
+                field: "auth",
+                parent: "Mutation",
+                type: "AuthPayload",
+                arguments: [],
+                selection: selection.__selection()
+            )
+
+            let result = OperationResult(
+                operation: operation,
+                data: [
+                    auth.alias!: [
+                        "__typename": "AuthPayloadSuccess",
+                        token.alias!: "123"
+                    ]
+                ],
+                error: nil
+            )
+            return Just(result).eraseToAnyPublisher()
+        })
+
+        let result = try await client.mutate(Objects.Mutation.auth(selection: selection))
+        XCTAssertEqual(result.data, "123")
+    }
+
+    func testAsyncSelectionMutationThrowsError() async throws {
+        let selection = Selection.AuthPayload<String?> {
+            try $0.on(
+                authPayloadSuccess: Selection.AuthPayloadSuccess<String?> {
+                    try $0.token()
+                },
+                authPayloadFailure: Selection.AuthPayloadFailure<String?> { _ in
+                    nil
+                }
+            )
+        }
+
+        let client = MockClient(customExecute: { operation in
+            let result = OperationResult(
+                operation: operation,
+                data: ["unknown_field": "123"],
+                error: nil
+            )
+            return Just(result).eraseToAnyPublisher()
+        })
+
+        await XCTAssertThrowsError(of: ObjectDecodingError.self) {
+            try await client.mutate(Objects.Mutation.auth(selection: selection))
+        }
+    }
+}

--- a/Tests/SwiftGraphQLClientTests/Extensions/Publishers+ExtensionsTests.swift
+++ b/Tests/SwiftGraphQLClientTests/Extensions/Publishers+ExtensionsTests.swift
@@ -116,4 +116,24 @@ final class PublishersExtensionsTests: XCTestCase {
         
         XCTAssertEqual(received, [1])
     }
+
+    func testTakeTheFirstEmittedValueAsynchronously() async throws {
+        let value = await Just(1).first()
+        XCTAssertEqual(value, 1)
+    }
+
+    func testTakeTheFirstEmittedValueAsynchronouslyFromThrowingPublisher() async throws {
+        struct TestError: Error {}
+
+        let value = try await Just(1).setFailureType(to: TestError.self).first()
+        XCTAssertEqual(value, 1)
+    }
+
+    func testThrowEmittedErrorAsynchronously() async throws {
+        struct TestError: Error {}
+
+        await XCTAssertThrowsError(of: TestError.self) {
+            try await Fail<Int, TestError>(error: TestError()).first()
+        }
+    }
 }

--- a/Tests/SwiftGraphQLClientTests/XCTest+Helpers.swift
+++ b/Tests/SwiftGraphQLClientTests/XCTest+Helpers.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Shaps Benkau on 27/10/2023.
+//
+
+import Foundation

--- a/Tests/SwiftGraphQLClientTests/XCTest+Helpers.swift
+++ b/Tests/SwiftGraphQLClientTests/XCTest+Helpers.swift
@@ -1,8 +1,16 @@
-//
-//  File.swift
-//  
-//
-//  Created by Shaps Benkau on 27/10/2023.
-//
+import XCTest
 
-import Foundation
+/// Checks whether the provided `body` throws an `error` of the given `error`'s type
+func XCTAssertThrowsError<T: Swift.Error, Output>(
+    of: T.Type,
+    file: StaticString = #file,
+    line: UInt = #line,
+    _ body: () async throws -> Output
+) async {
+    do {
+        _ = try await body()
+        XCTFail("body completed successfully", file: file, line: line)
+    } catch let error {
+        XCTAssertNotNil(error as? T, "Expected error of \(T.self), got \(type(of: error))")
+    }
+}

--- a/Tests/SwiftGraphQLCodegenTests/Integration/API.swift
+++ b/Tests/SwiftGraphQLCodegenTests/Integration/API.swift
@@ -63,7 +63,7 @@ extension Fields where TypeLock == Objects.User {
   }
 }
 extension Selection where TypeLock == Never, T == Never {
-  typealias User<T> = Selection<T, Objects.User>
+  typealias User<W> = Selection<W, Objects.User>
 }
 extension Objects {
   struct Query {
@@ -225,7 +225,7 @@ extension Fields where TypeLock == Objects.Query {
   }
 }
 extension Selection where TypeLock == Never, T == Never {
-  typealias Query<T> = Selection<T, Objects.Query>
+  typealias Query<W> = Selection<W, Objects.Query>
 }
 extension Objects {
   struct Character {
@@ -323,7 +323,7 @@ extension Fields where TypeLock == Objects.Character {
   }
 }
 extension Selection where TypeLock == Never, T == Never {
-  typealias Character<T> = Selection<T, Objects.Character>
+  typealias Character<W> = Selection<W, Objects.Character>
 }
 extension Objects {
   struct Comic {
@@ -452,7 +452,7 @@ extension Fields where TypeLock == Objects.Comic {
   }
 }
 extension Selection where TypeLock == Never, T == Never {
-  typealias Comic<T> = Selection<T, Objects.Comic>
+  typealias Comic<W> = Selection<W, Objects.Comic>
 }
 extension Objects {
   struct Mutation {
@@ -564,7 +564,7 @@ extension Fields where TypeLock == Objects.Mutation {
   }
 }
 extension Selection where TypeLock == Never, T == Never {
-  typealias Mutation<T> = Selection<T, Objects.Mutation>
+  typealias Mutation<W> = Selection<W, Objects.Mutation>
 }
 extension Objects {
   struct AuthPayloadSuccess {
@@ -613,7 +613,7 @@ extension Fields where TypeLock == Objects.AuthPayloadSuccess {
   }
 }
 extension Selection where TypeLock == Never, T == Never {
-  typealias AuthPayloadSuccess<T> = Selection<T, Objects.AuthPayloadSuccess>
+  typealias AuthPayloadSuccess<W> = Selection<W, Objects.AuthPayloadSuccess>
 }
 extension Objects {
   struct AuthPayloadFailure {
@@ -644,7 +644,7 @@ extension Fields where TypeLock == Objects.AuthPayloadFailure {
   }
 }
 extension Selection where TypeLock == Never, T == Never {
-  typealias AuthPayloadFailure<T> = Selection<T, Objects.AuthPayloadFailure>
+  typealias AuthPayloadFailure<W> = Selection<W, Objects.AuthPayloadFailure>
 }
 extension Objects {
   struct File {
@@ -709,7 +709,7 @@ extension Fields where TypeLock == Objects.File {
   }
 }
 extension Selection where TypeLock == Never, T == Never {
-  typealias File<T> = Selection<T, Objects.File>
+  typealias File<W> = Selection<W, Objects.File>
 }
 extension Objects {
   struct Subscription {
@@ -857,7 +857,7 @@ extension Fields where TypeLock == Objects.Message {
   }
 }
 extension Selection where TypeLock == Never, T == Never {
-  typealias Message<T> = Selection<T, Objects.Message>
+  typealias Message<W> = Selection<W, Objects.Message>
 }
 extension Objects.User {
 
@@ -1257,7 +1257,7 @@ extension Fields where TypeLock == Interfaces.Node {
 }
 
 extension Selection where TypeLock == Never, T == Never {
-  typealias Node<T> = Selection<T, Interfaces.Node>
+  typealias Node<W> = Selection<W, Interfaces.Node>
 }
 
 // MARK: - Unions
@@ -1303,7 +1303,7 @@ extension Fields where TypeLock == Unions.SearchResult {
 }
 
 extension Selection where TypeLock == Never, T == Never {
-  typealias SearchResult<T> = Selection<T, Unions.SearchResult>
+  typealias SearchResult<W> = Selection<W, Unions.SearchResult>
 }
 extension Unions {
   struct AuthPayload {
@@ -1349,7 +1349,7 @@ extension Fields where TypeLock == Unions.AuthPayload {
 }
 
 extension Selection where TypeLock == Never, T == Never {
-  typealias AuthPayload<T> = Selection<T, Unions.AuthPayload>
+  typealias AuthPayload<W> = Selection<W, Unions.AuthPayload>
 }
 
 // MARK: - Enums


### PR DESCRIPTION
This introduces an initial light-weight improvement to concurrency, bringing minimal async/await support to some of the surface level APIs.

v6 will later introduce a much deeper integration that covers more API, as such there are minor caveats with this approach and as such, header docs have been updated to ensure a developer has improved expectations and alternative recommendations.