### PR TITLE
fix: correct starscream dependency minimum version to 4.0.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-format", "508.0.0"..<"510.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
-        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0"),
+        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.5"),
         .package(url: "https://github.com/dominicegginton/Spinner", from: "2.0.0"),
         .package(url: "https://github.com/JohnSundell/Files", from: "4.0.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),


### PR DESCRIPTION
My project was resolving to 4.0.4 of starscream which I found to be incompatible with v5.1 of swift-graphql. This PR simply updates to the min version starscream version accordingly.

The following breaking changes were made in v4.0.5 of starscream:
* https://github.com/daltoniam/Starscream/commit/e95db8ff2984884288f8b2e8232766c02e93082d
* https://github.com/daltoniam/Starscream/commit/f900d67759cdd11df3dcca34af21f40f59fe4e79