### PR TITLE
Improve code generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 *.log*
-.env*
 
 # Swift
 

--- a/Sources/SwiftGraphQLCLI/main.swift
+++ b/Sources/SwiftGraphQLCLI/main.swift
@@ -115,7 +115,10 @@ struct SwiftGraphQLCLI: ParsableCommand {
         let files: [GeneratedFile]
 
         do {
-            files = try generator.generate(schema: schema, generateStaticFields: config.generateStaticFields)
+            files = try generator.generate(
+                schema: schema,
+                generateStaticFields: config.generateStaticFields != false
+            )
             generateCodeSpinner.success("API generated successfully!")
         } catch CodegenError.formatting(let err) {
             generateCodeSpinner.error(err.localizedDescription)
@@ -181,13 +184,14 @@ struct Config: Codable, Equatable {
     let scalars: [String: String]
 
     /// Whether to generate static lookups for object fields
-    var generateStaticFields = true
+    var generateStaticFields: Bool?
 
     // MARK: - Initializers
 
     /// Creates an empty configuration instance.
     init() {
         self.scalars = [:]
+        self.generateStaticFields = true
     }
 
     /// Tries to decode the configuration from a string.

--- a/Sources/SwiftGraphQLCLI/main.swift
+++ b/Sources/SwiftGraphQLCLI/main.swift
@@ -115,7 +115,7 @@ struct SwiftGraphQLCLI: ParsableCommand {
         let files: [GeneratedFile]
 
         do {
-            files = try generator.generate(schema: schema)
+            files = try generator.generate(schema: schema, generateStaticFields: config.generateStaticFields)
             generateCodeSpinner.success("API generated successfully!")
         } catch CodegenError.formatting(let err) {
             generateCodeSpinner.error(err.localizedDescription)
@@ -179,6 +179,9 @@ struct SwiftGraphQLCLI: ParsableCommand {
 struct Config: Codable, Equatable {
     /// Key-Value dictionary of scalar mappings.
     let scalars: [String: String]
+
+    /// Whether to generate static lookups for object fields
+    var generateStaticFields = true
 
     // MARK: - Initializers
 

--- a/Sources/SwiftGraphQLCLI/main.swift
+++ b/Sources/SwiftGraphQLCLI/main.swift
@@ -115,7 +115,8 @@ struct SwiftGraphQLCLI: ParsableCommand {
         let files: [GeneratedFile]
 
         // If the output is a Swift file generate a single file, otherwise multiple files in that directory
-        let singleFileOutput = output?.hasSuffix(".swift") ?? false
+        // If there's no output generate a single file as well as it will be printed to standard out
+        let singleFileOutput = output?.hasSuffix(".swift") ?? true
 
         do {
             files = try generator.generate(
@@ -150,8 +151,8 @@ struct SwiftGraphQLCLI: ParsableCommand {
             }
         } else {
             for file in files {
-                let contents = "\n" + file.contents
-                FileHandle.standardOutput.write(contents.data(using: .utf8)!)
+                // this should always be one file anyway
+                FileHandle.standardOutput.write(file.contents.data(using: .utf8)!)
             }
         }
         

--- a/Sources/SwiftGraphQLCodegen/Generator.swift
+++ b/Sources/SwiftGraphQLCodegen/Generator.swift
@@ -23,70 +23,79 @@ public struct GraphQLCodegen {
         let objects = schema.objects
         // Code Parts
         let operations = schema.operations.map { $0.declaration() }
-        let objectDefinitions = try objects.map { object in
-            try object.declaration(
-                objects: objects,
-                context: context,
-                alias: object.name != subscription
-            )
-        }
-        
-        let staticFieldSelection = try objects.map { object in
-            try object.statics(context: context)
-        }
-        
-        let interfaceDefinitions = try schema.interfaces.map {
-            try $0.declaration(objects: objects, context: context)
-        }
-        
-        let unionDefinitions = try schema.unions.map {
-            try $0.declaration(objects: objects, context: context)
-        }
-        
-        let enumDefinitions = schema.enums.map { $0.declaration }
-        
-        let inputObjectDefinitions = try schema.inputObjects.map {
-            try $0.declaration(context: context)
-        }
-        
-        // API
-        let code = """
-        // This file was auto-generated using maticzav/swift-graphql. DO NOT EDIT MANUALLY!
-        import Foundation
-        import GraphQL
-        import SwiftGraphQL
 
+        var files: [GeneratedFile] = []
+
+        func addFile(name: String, contents: String) throws {
+            let fileContents = """
+            // This file was auto-generated using maticzav/swift-graphql. DO NOT EDIT MANUALLY!
+            import Foundation
+            import GraphQL
+            import SwiftGraphQL
+
+            \(contents)
+            """
+            let file = GeneratedFile(name: name, contents: try fileContents.format())
+            files.append(file)
+        }
+
+        // API
+        let graphContents = """
         // MARK: - Operations
         public enum Operations {}
         \(operations.lines)
 
-        // MARK: - Objects
         public enum Objects {}
-        \(objectDefinitions.lines)
-        \(staticFieldSelection.lines)
 
-        // MARK: - Interfaces
         public enum Interfaces {}
-        \(interfaceDefinitions.lines)
 
-        // MARK: - Unions
         public enum Unions {}
-        \(unionDefinitions.lines)
 
-        // MARK: - Enums
         public enum Enums {}
-        \(enumDefinitions.lines)
 
-        // MARK: - Input Objects
-        
         /// Utility pointer to InputObjects.
         public typealias Inputs = InputObjects
         
         public enum InputObjects {}
-        \(inputObjectDefinitions.lines)
         """
 
-        let formatted = try code.format()
-        return formatted
+        try addFile(name: "Graph", contents: graphContents)
+        for object in objects {
+            var contents = try object.declaration(
+                objects: objects,
+                context: context,
+                alias: object.name != subscription
+            )
+
+            let staticFieldSelection = try object.statics(context: context)
+            contents += "\n\n\(staticFieldSelection)"
+            try addFile(name: "Objects/\(object.name)", contents: contents)
+        }
+
+        for object in schema.inputObjects {
+            let contents = try object.declaration(context: context)
+            try addFile(name: "InputObjects/\(object.name)", contents: contents)
+        }
+
+        for enumSchema in schema.enums {
+            try addFile(name: "Enums/\(enumSchema.name)", contents: enumSchema.declaration)
+        }
+
+        for interface in schema.interfaces {
+            let contents = try interface.declaration(objects: objects, context: context)
+            try addFile(name: "Interfaces/\(interface.name)", contents: contents)
+        }
+
+        for union in schema.unions {
+            let contents = try union.declaration(objects: objects, context: context)
+            try addFile(name: "Unions/\(union.name)", contents: contents)
+        }
+
+        return files
     }
+}
+
+public struct GeneratedFile {
+    public let name: String
+    public let contents: String
 }

--- a/Sources/SwiftGraphQLCodegen/Generator.swift
+++ b/Sources/SwiftGraphQLCodegen/Generator.swift
@@ -20,27 +20,27 @@ public struct GraphQLCodegen {
         let context = Context(schema: schema, scalars: self.scalars)
         
         let subscription = schema.operations.first { $0.isSubscription }?.type.name
-        
+        let objects = schema.objects
         // Code Parts
         let operations = schema.operations.map { $0.declaration() }
-        let objectDefinitions = try schema.objects.map { object in
+        let objectDefinitions = try objects.map { object in
             try object.declaration(
-                objects: schema.objects,
+                objects: objects,
                 context: context,
                 alias: object.name != subscription
             )
         }
         
-        let staticFieldSelection = try schema.objects.map { object in
+        let staticFieldSelection = try objects.map { object in
             try object.statics(context: context)
         }
         
         let interfaceDefinitions = try schema.interfaces.map {
-            try $0.declaration(objects: schema.objects, context: context)
+            try $0.declaration(objects: objects, context: context)
         }
         
         let unionDefinitions = try schema.unions.map {
-            try $0.declaration(objects: schema.objects, context: context)
+            try $0.declaration(objects: objects, context: context)
         }
         
         let enumDefinitions = schema.enums.map { $0.declaration }

--- a/Sources/SwiftGraphQLCodegen/Generator.swift
+++ b/Sources/SwiftGraphQLCodegen/Generator.swift
@@ -16,7 +16,7 @@ public struct GraphQLCodegen {
     // MARK: - Methods
 
     /// Generates a SwiftGraphQL Selection File (i.e. the code that tells how to define selections).
-    public func generate(schema: Schema) throws -> String {
+    public func generate(schema: Schema, generateStaticFields: Bool) throws -> [GeneratedFile] {
         let context = Context(schema: schema, scalars: self.scalars)
         
         let subscription = schema.operations.first { $0.isSubscription }?.type.name
@@ -67,8 +67,10 @@ public struct GraphQLCodegen {
                 alias: object.name != subscription
             )
 
-            let staticFieldSelection = try object.statics(context: context)
-            contents += "\n\n\(staticFieldSelection)"
+            if generateStaticFields {
+                let staticFieldSelection = try object.statics(context: context)
+                contents += "\n\n\(staticFieldSelection)"
+            }
             try addFile(name: "Objects/\(object.name)", contents: contents)
         }
 

--- a/examples/thesocialnetwork/README.md
+++ b/examples/thesocialnetwork/README.md
@@ -7,12 +7,26 @@ A sample server for a social network that
 - uses subscriptions,
 - lets users write to a shared feed.
 
+```bash
+# Start Server
+yarn start
+
+# Generate Prisma Client
+yarn prisma generate
+
+# Generate TypeGen
+yarn generate
+```
+
+
 ### Development Setup
 
 Start local Postgres database using Docker Compose.
 
 ```bash
+# Start DB in the background
 docker-compose up -d
 
-export DATABASE_URL="postgresql://prisma:prisma@localhost:5432/prisma"
+# Setup Environment variables
+cp .env.example .env
 ```

--- a/examples/thesocialnetwork/server/.env.example
+++ b/examples/thesocialnetwork/server/.env.example
@@ -1,0 +1,6 @@
+AWS_S3_BUCKET="thesocialnetwork-images"
+AWS_ACCESS_KEY_ID="AKIA3JJIBRRXWTIC7"
+AWS_SECRET_ACCESS_KEY="puU+kTKu288s+K9HpcbPGIrX79TItKly"
+
+DATABASE_URL="postgresql://prisma:prisma@localhost:5432/prisma"
+


### PR DESCRIPTION
This PR improves code generation by:
### 1. Generating seperate files instead of one big one
Files are split up for each Object, Interface, Enum, Union, and InputObject, and organised in their own subfolder with the same names.

With our schema and on my machine, generation went from 25s to 10s, and clean build time of the resulting source files went from 191s to 26s! It also makes diffs much more readable, especially as opening or viewing diffs in the mega file before was unusable due to it's file size.

To use it just make the `--output` argument a folder instead of a `.swift` file

### 2. Disable  generation of static selection fields
- adding a config option `generateStaticFields`. We don't touch these in our usage, so it saves a bunch of useless code being generated and compiled.

---
I understand this project is undergoing a major re-design. I don't expect this to be merged, but thought I'd leave it here in case it's useful for others.